### PR TITLE
feat: VerifierRouter v0

### DIFF
--- a/circom/contracts/VerifierRouter.sol
+++ b/circom/contracts/VerifierRouter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.20;
+pragma solidity ^0.8.26;
 
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
 
@@ -14,9 +14,9 @@ struct VerifierInfo {
 /// @notice Routes verification requests to appropriate registered verifier contracts
 /// @dev Acts as a central registry and gateway for multiple ZK verification contracts
 contract VerifierRouter is Ownable {
-    error InvalidVerifierAddress();
-    error VerifierAlreadyRegistered();
-    error VerifierNotRegistered();
+    error InvalidVerifierAddress(address verifier);
+    error VerifierAlreadyRegistered(uint256 verifierId);
+    error VerifierNotRegistered(uint256 verifierId);
     error VerificationFailed();
 
     event VerifierRegistered(uint256 indexed id, address indexed verifier, bytes4 functionSelector);
@@ -29,28 +29,6 @@ contract VerifierRouter is Ownable {
 
     constructor(address initialOwner) Ownable(initialOwner) {}
 
-    /// @notice Verifies a proof using the specified verifier
-    /// @param verifierId The ID of the verifier to use
-    /// @param a First part of the ZK proof
-    /// @param b Second part of the ZK proof
-    /// @param c Third part of the ZK proof
-    /// @param publicOutputs Public inputs to the ZK circuit
-    function verify(
-        uint256 verifierId,
-        uint256[2] calldata a,
-        uint256[2][2] calldata b,
-        uint256[2] calldata c,
-        uint256[] calldata publicOutputs
-    ) external view {
-        VerifierInfo memory info = verifierRegistry[verifierId];
-        if (info.verifierAddress == address(0)) revert VerifierNotRegistered();
-
-        bytes memory data = abi.encodePacked(info.functionSelector, a, b, c, publicOutputs);
-
-        (bool success,) = info.verifierAddress.staticcall(data);
-        if (!success) revert VerificationFailed();
-    }
-
     /// @notice Registers a new verifier contract
     /// @param verifierId Unique identifier for the verifier
     /// @param verifierAddress Address of the verifier contract
@@ -59,8 +37,10 @@ contract VerifierRouter is Ownable {
         external
         onlyOwner
     {
-        if (verifierAddress == address(0)) revert InvalidVerifierAddress();
-        if (verifierRegistry[verifierId].verifierAddress != address(0)) revert VerifierAlreadyRegistered();
+        if (verifierAddress == address(0)) revert InvalidVerifierAddress(verifierAddress);
+        if (verifierRegistry[verifierId].verifierAddress != address(0)) {
+            revert VerifierAlreadyRegistered(verifierId);
+        }
 
         verifierRegistry[verifierId] = VerifierInfo(verifierAddress, functionSelector);
         emit VerifierRegistered(verifierId, verifierAddress, functionSelector);
@@ -71,8 +51,7 @@ contract VerifierRouter is Ownable {
     /// @param verifierAddress New address of the verifier contract
     /// @param functionSelector New function selector for the verification method
     function updateVerifier(uint256 verifierId, address verifierAddress, bytes4 functionSelector) external onlyOwner {
-        if (verifierAddress == address(0)) revert InvalidVerifierAddress();
-        if (verifierRegistry[verifierId].verifierAddress == address(0)) revert VerifierNotRegistered();
+        if (verifierRegistry[verifierId].verifierAddress == address(0)) revert VerifierNotRegistered(verifierId);
 
         address oldVerifier = verifierRegistry[verifierId].verifierAddress;
         verifierRegistry[verifierId] = VerifierInfo(verifierAddress, functionSelector);
@@ -82,7 +61,7 @@ contract VerifierRouter is Ownable {
     /// @notice Unregisters a verifier
     /// @param verifierId Identifier of the verifier to remove
     function unregisterVerifier(uint256 verifierId) external onlyOwner {
-        if (verifierRegistry[verifierId].verifierAddress == address(0)) revert VerifierNotRegistered();
+        if (verifierRegistry[verifierId].verifierAddress == address(0)) revert VerifierNotRegistered(verifierId);
         // Unchecked block to save gas since there's no risk of underflow/overflow when deleting
         unchecked {
             delete verifierRegistry[verifierId];
@@ -101,6 +80,30 @@ contract VerifierRouter is Ownable {
     /// @param verifierId The ID of the verifier.
     /// @return The verifier information.
     function getVerifierInfo(uint256 verifierId) external view returns (VerifierInfo memory) {
+        if (verifierRegistry[verifierId].verifierAddress == address(0)) revert VerifierNotRegistered(verifierId);
+
         return verifierRegistry[verifierId];
+    }
+
+    /// @notice Verifies a proof using the specified verifier
+    /// @param verifierId The ID of the verifier to use
+    /// @param a First part of the ZK proof
+    /// @param b Second part of the ZK proof
+    /// @param c Third part of the ZK proof
+    /// @param publicOutputs Public inputs to the ZK circuit
+    function verify(
+        uint256 verifierId,
+        uint256[2] calldata a,
+        uint256[2][2] calldata b,
+        uint256[2] calldata c,
+        uint256[] calldata publicOutputs
+    ) external view {
+        VerifierInfo memory info = verifierRegistry[verifierId];
+        if (info.verifierAddress == address(0)) revert VerifierNotRegistered(verifierId);
+
+        bytes memory data = abi.encodePacked(info.functionSelector, a, b, c, publicOutputs);
+
+        (bool success,) = info.verifierAddress.staticcall(data);
+        if (!success) revert VerificationFailed();
     }
 }

--- a/circom/contracts/VerifierRouter.sol
+++ b/circom/contracts/VerifierRouter.sol
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+
+/// @title Verifier Information Structure
+/// @notice Stores details about registered ZK verifier contracts
+struct VerifierInfo {
+    address verifierAddress;
+    bytes4 functionSelector;
+}
+
+/// @title ZK Verifier Router Contract
+/// @notice Routes verification requests to appropriate registered verifier contracts
+/// @dev Acts as a central registry and gateway for multiple ZK verification contracts
+contract VerifierRouter is Ownable {
+    error InvalidVerifierAddress();
+    error VerifierAlreadyRegistered();
+    error VerifierNotRegistered();
+    error VerificationFailed();
+
+    event VerifierRegistered(uint256 indexed id, address indexed verifier, bytes4 functionSelector);
+    event VerifierUpdated(
+        uint256 indexed id, address indexed oldVerifier, address indexed newVerifier, bytes4 functionSelector
+    );
+    event VerifierUnregistered(uint256 indexed id);
+
+    mapping(uint256 => VerifierInfo) public verifierRegistry;
+
+    constructor(address initialOwner) Ownable(initialOwner) {}
+
+    /// @notice Verifies a proof using the specified verifier
+    /// @param verifierId The ID of the verifier to use
+    /// @param a First part of the ZK proof
+    /// @param b Second part of the ZK proof
+    /// @param c Third part of the ZK proof
+    /// @param publicOutputs Public inputs to the ZK circuit
+    function verify(
+        uint256 verifierId,
+        uint256[2] calldata a,
+        uint256[2][2] calldata b,
+        uint256[2] calldata c,
+        uint256[] calldata publicOutputs
+    ) external view {
+        VerifierInfo memory info = verifierRegistry[verifierId];
+        if (info.verifierAddress == address(0)) revert VerifierNotRegistered();
+
+        bytes memory data = abi.encodePacked(info.functionSelector, a, b, c, publicOutputs);
+
+        (bool success,) = info.verifierAddress.staticcall(data);
+        if (!success) revert VerificationFailed();
+    }
+
+    /// @notice Registers a new verifier contract
+    /// @param verifierId Unique identifier for the verifier
+    /// @param verifierAddress Address of the verifier contract
+    /// @param functionSelector Function selector for the verification method
+    function registerVerifier(uint256 verifierId, address verifierAddress, bytes4 functionSelector)
+        external
+        onlyOwner
+    {
+        if (verifierAddress == address(0)) revert InvalidVerifierAddress();
+        if (verifierRegistry[verifierId].verifierAddress != address(0)) revert VerifierAlreadyRegistered();
+
+        verifierRegistry[verifierId] = VerifierInfo(verifierAddress, functionSelector);
+        emit VerifierRegistered(verifierId, verifierAddress, functionSelector);
+    }
+
+    /// @notice Updates an existing verifier contract
+    /// @param verifierId Identifier of the verifier to update
+    /// @param verifierAddress New address of the verifier contract
+    /// @param functionSelector New function selector for the verification method
+    function updateVerifier(uint256 verifierId, address verifierAddress, bytes4 functionSelector) external onlyOwner {
+        if (verifierAddress == address(0)) revert InvalidVerifierAddress();
+        if (verifierRegistry[verifierId].verifierAddress == address(0)) revert VerifierNotRegistered();
+
+        address oldVerifier = verifierRegistry[verifierId].verifierAddress;
+        verifierRegistry[verifierId] = VerifierInfo(verifierAddress, functionSelector);
+        emit VerifierUpdated(verifierId, oldVerifier, verifierAddress, functionSelector);
+    }
+
+    /// @notice Unregisters a verifier
+    /// @param verifierId Identifier of the verifier to remove
+    function unregisterVerifier(uint256 verifierId) external onlyOwner {
+        if (verifierRegistry[verifierId].verifierAddress == address(0)) revert VerifierNotRegistered();
+        // Unchecked block to save gas since there's no risk of underflow/overflow when deleting
+        unchecked {
+            delete verifierRegistry[verifierId];
+        }
+        emit VerifierUnregistered(verifierId);
+    }
+
+    /// @notice Checks if a verifier is registered
+    /// @param verifierId Identifier of the verifier to check
+    /// @return isRegistered Whether the verifier is registered
+    function isVerifierRegistered(uint256 verifierId) external view returns (bool) {
+        return verifierRegistry[verifierId].verifierAddress != address(0);
+    }
+
+    /// @notice Retrieves verifier information by ID.
+    /// @param verifierId The ID of the verifier.
+    /// @return The verifier information.
+    function getVerifierInfo(uint256 verifierId) external view returns (VerifierInfo memory) {
+        return verifierRegistry[verifierId];
+    }
+}

--- a/circom/contracts/interfaces/IVerifier.sol
+++ b/circom/contracts/interfaces/IVerifier.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+interface IVerifier {
+    function verify(
+        uint256[2] calldata a,
+        uint256[2][2] calldata b,
+        uint256[2] calldata c,
+        uint256[16] calldata publicOutputs
+    ) external view;
+}

--- a/circom/test/contracts/VerifierRouter/_VerifierRouterBase.t.sol
+++ b/circom/test/contracts/VerifierRouter/_VerifierRouterBase.t.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {Test} from "forge-std/Test.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {TestVerifier} from "../../../contracts/test/TestVerifier.sol";
+import {VerifierRouter} from "../../../contracts/VerifierRouter.sol";
+
+contract VerifierRouterBaseTest is Test {
+    address alice;
+    VerifierRouter router;
+    uint256 verifierId;
+    address verifierAddress;
+    bytes4 verifySelector;
+
+    function setUp() public virtual {
+        alice = vm.randomAddress();
+        verifierId = vm.randomUint();
+        verifierAddress = vm.randomAddress();
+        verifySelector = TestVerifier.verify.selector;
+
+        address owner = address(this);
+        router = new VerifierRouter(owner);
+
+        router.registerVerifier(verifierId, verifierAddress, verifySelector);
+    }
+}

--- a/circom/test/contracts/VerifierRouter/getVerifierInfo.t.sol
+++ b/circom/test/contracts/VerifierRouter/getVerifierInfo.t.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {VerifierRouterBaseTest} from "./_VerifierRouterBase.t.sol";
+import {VerifierInfo} from "../../../contracts/VerifierRouter.sol";
+import {VerifierRouter} from "../../../contracts/VerifierRouter.sol";
+
+contract RegisterVerifierTest is VerifierRouterBaseTest {
+    function test_RevertWhen_VerifierNotRegistered() public {
+        verifierId = vm.randomUint();
+
+        vm.expectRevert(abi.encodeWithSelector(VerifierRouter.VerifierNotRegistered.selector, verifierId));
+        router.getVerifierInfo(verifierId);
+    }
+
+    function test_CorrectResult() public view {
+        VerifierInfo memory verifierInfo = router.getVerifierInfo(verifierId);
+
+        assertTrue(verifierInfo.verifierAddress == verifierAddress);
+        assertTrue(verifierInfo.functionSelector == verifySelector);
+    }
+}

--- a/circom/test/contracts/VerifierRouter/isVerifierRegistered.t.sol
+++ b/circom/test/contracts/VerifierRouter/isVerifierRegistered.t.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {VerifierRouterBaseTest} from "./_VerifierRouterBase.t.sol";
+
+contract RegisterVerifierTest is VerifierRouterBaseTest {
+    function test_NotRegistered() public {
+        verifierId = vm.randomUint();
+
+        bool isRegistered = router.isVerifierRegistered(verifierId);
+        assertFalse(isRegistered);
+    }
+
+    function test_Registered() public view {
+        bool isRegistered = router.isVerifierRegistered(verifierId);
+        assertTrue(isRegistered);
+    }
+}

--- a/circom/test/contracts/VerifierRouter/registerVerifier.t.sol
+++ b/circom/test/contracts/VerifierRouter/registerVerifier.t.sol
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {VerifierRouterBaseTest} from "./_VerifierRouterBase.t.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {VerifierRouter} from "../../../contracts/VerifierRouter.sol";
+
+contract RegisterVerifierTest is VerifierRouterBaseTest {
+    uint256 registeredVerifierId;
+
+    function setUp() public override {
+        super.setUp();
+
+        registeredVerifierId = verifierId;
+        verifierId = vm.randomUint();
+    }
+
+    function test_RegisterVerifier_RevertWhen_NotOwner() public {
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, alice));
+        router.registerVerifier(verifierId, verifierAddress, verifySelector);
+    }
+
+    function test_RevertWhen_InvalidVerifierAddress() public {
+        address invalidAddress = address(0);
+
+        vm.expectRevert(abi.encodeWithSelector(VerifierRouter.InvalidVerifierAddress.selector, invalidAddress));
+        router.registerVerifier(verifierId, invalidAddress, verifySelector);
+    }
+
+    function test_RevertWhen_VerifierAlreadyRegistered() public {
+        verifierId = registeredVerifierId;
+
+        vm.expectRevert(abi.encodeWithSelector(VerifierRouter.VerifierAlreadyRegistered.selector, verifierId));
+        router.registerVerifier(verifierId, verifierAddress, verifySelector);
+    }
+
+    function test_VerifierRegisteredEvent() public {
+        vm.expectEmit();
+        emit VerifierRouter.VerifierRegistered(verifierId, verifierAddress, verifySelector);
+        router.registerVerifier(verifierId, verifierAddress, verifySelector);
+    }
+}

--- a/circom/test/contracts/VerifierRouter/unregisterVerifier.t.sol
+++ b/circom/test/contracts/VerifierRouter/unregisterVerifier.t.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {VerifierRouterBaseTest} from "./_VerifierRouterBase.t.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {VerifierRouter} from "../../../contracts/VerifierRouter.sol";
+
+contract UnregisterVerifierTest is VerifierRouterBaseTest {
+    function test_RevertWhen_NotOwner() public {
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, alice));
+        router.unregisterVerifier(verifierId);
+    }
+
+    function test_RevertWhen_VerifierNotRegistered() public {
+        verifierId = vm.randomUint();
+
+        vm.expectRevert(abi.encodeWithSelector(VerifierRouter.VerifierNotRegistered.selector, verifierId));
+        router.unregisterVerifier(verifierId);
+    }
+
+    function test_VerifierUnregisteredEvent() public {
+        vm.expectEmit();
+        emit VerifierRouter.VerifierUnregistered(verifierId);
+        router.unregisterVerifier(verifierId);
+    }
+}

--- a/circom/test/contracts/VerifierRouter/updateVerifier.t.sol
+++ b/circom/test/contracts/VerifierRouter/updateVerifier.t.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {VerifierRouterBaseTest} from "./_VerifierRouterBase.t.sol";
+import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {TestVerifier} from "../../../contracts/test/TestVerifier.sol";
+import {VerifierRouter} from "../../../contracts/VerifierRouter.sol";
+
+contract RegisterVerifierTest is VerifierRouterBaseTest {
+    address newVerifierAddress;
+
+    function setUp() public override {
+        super.setUp();
+        newVerifierAddress = vm.randomAddress();
+    }
+
+    function test_RegisterVerifier_RevertWhen_NotOwner() public {
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(Ownable.OwnableUnauthorizedAccount.selector, alice));
+        router.updateVerifier(verifierId, newVerifierAddress, verifySelector);
+    }
+
+    function test_RevertWhen_VerifierNotRegistered() public {
+        verifierId = vm.randomUint();
+
+        vm.expectRevert(abi.encodeWithSelector(VerifierRouter.VerifierNotRegistered.selector, verifierId));
+        router.updateVerifier(verifierId, newVerifierAddress, verifySelector);
+    }
+
+    function test_VerifierUpdatedEvent() public {
+        vm.expectEmit();
+        emit VerifierRouter.VerifierUpdated(verifierId, verifierAddress, newVerifierAddress, verifySelector);
+        router.updateVerifier(verifierId, newVerifierAddress, verifySelector);
+    }
+}

--- a/circom/test/contracts/VerifierRouter/verify.t.sol
+++ b/circom/test/contracts/VerifierRouter/verify.t.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import {VerifierRouterBaseTest} from "./_VerifierRouterBase.t.sol";
+import {VerifierRouter} from "../../../contracts/VerifierRouter.sol";
+
+contract VerifyTest is VerifierRouterBaseTest {
+    uint256[2] a;
+    uint256[2][2] b;
+    uint256[2] c;
+    uint256[16] publicOutputsFixedSize;
+    uint256[] publicOutputs = new uint256[](16);
+
+    function setUp() public override {
+        super.setUp();
+
+        a = [vm.randomUint(), vm.randomUint()];
+        b = [[vm.randomUint(), vm.randomUint()], [vm.randomUint(), vm.randomUint()]];
+        c = [vm.randomUint(), vm.randomUint()];
+
+        for (uint256 i = 0; i < 16; i++) {
+            publicOutputsFixedSize[i] = vm.randomUint();
+            publicOutputs[i] = publicOutputsFixedSize[i];
+        }
+    }
+
+    function test_RevertWhen_VerifierNotRegistered() public {
+        verifierId = verifierId + 9;
+
+        vm.expectRevert(abi.encodeWithSelector(VerifierRouter.VerifierNotRegistered.selector, verifierId));
+        router.verify(verifierId, a, b, c, publicOutputs);
+    }
+
+    function test_RevertWhen_VerifierRevert() public {
+        vm.mockCallRevert(verifierAddress, verifySelector, vm.randomBytes(88));
+
+        vm.expectRevert(VerifierRouter.VerificationFailed.selector);
+        router.verify(verifierId, a, b, c, publicOutputs);
+    }
+
+    function test_SuccessWhen_VerifierSuccess() public {
+        vm.mockCall(verifierAddress, verifySelector, "");
+
+        vm.expectCall(verifierAddress, abi.encodeWithSelector(verifySelector, a, b, c, publicOutputsFixedSize));
+        router.verify(verifierId, a, b, c, publicOutputs);
+    }
+}


### PR DESCRIPTION
### Summary
This pull request introduces a new `VerifierRouter` contract and its associated interface and tests. The `VerifierRouter` contract acts as a central registry and gateway for multiple ZK verification contracts. The most important changes include the implementation of the `VerifierRouter` contract, the addition of the `IVerifier` interface, and the creation of comprehensive tests for the router's functionality.

### Implementation of `VerifierRouter` contract:

* [`contracts/VerifierRouter.sol`](diffhunk://#diff-53ed415b0d01d453eba40da30201a66cc41a3eecfbf7b0b86872234c9626b77bR1-R109): Added the `VerifierRouter` contract, which includes methods for registering, updating, and unregistering verifiers, as well as verifying proofs. The contract also defines custom errors and events for better error handling and logging.

### Addition of `IVerifier` interface:

* [`contracts/interfaces/IVerifier.sol`](diffhunk://#diff-768031911fd3fb95266da371592035ff38cc26458e416f08b75f687f5276bcbdR1-R11): Added the `IVerifier` interface, which defines the `verify` function that verifier contracts must implement.