### PR TITLE
chore: circom general cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -626,7 +626,7 @@ dependencies = [
  "dotenv",
  "rand",
  "regex",
- "relayer-utils",
+ "relayer-utils 0.4.62-12 (git+https://github.com/zkemail/relayer-utils?rev=728b8f643a6c9a1e5b400be6407727851cc8c92c)",
  "sdk-utils 0.1.0 (git+https://github.com/zkemail/sdk-images?branch=main)",
  "serde",
  "serde_json",
@@ -3040,7 +3040,7 @@ dependencies = [
  "compiler",
  "dotenv",
  "regex",
- "relayer-utils",
+ "relayer-utils 0.4.62-12 (git+https://github.com/zkemail/relayer-utils?rev=728b8f643a6c9a1e5b400be6407727851cc8c92c)",
  "sdk-utils 0.1.0",
  "serde",
  "serde_json",
@@ -4057,6 +4057,49 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 [[package]]
 name = "relayer-utils"
 version = "0.4.62-12"
+source = "git+https://github.com/zkemail/relayer-utils?rev=728b8f643a6c9a1e5b400be6407727851cc8c92c#728b8f643a6c9a1e5b400be6407727851cc8c92c"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "cfdkim",
+ "console_error_panic_hook",
+ "digest",
+ "ed25519-dalek",
+ "ethers",
+ "file-rotate",
+ "halo2curves",
+ "hex",
+ "hmac-sha256",
+ "itertools 0.10.5",
+ "js-sys",
+ "lazy_static",
+ "mailparse",
+ "num-bigint",
+ "poseidon-rs",
+ "rand",
+ "rand_core",
+ "regex",
+ "reqwest 0.11.27",
+ "rsa",
+ "serde",
+ "serde-wasm-bindgen",
+ "serde_json",
+ "sha1",
+ "sha2",
+ "slog",
+ "slog-async",
+ "slog-json",
+ "slog-term",
+ "sp1-verifier",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "zk-regex-apis",
+ "zk-regex-compiler 2.3.2 (git+https://github.com/zkemail/zk-regex.git)",
+]
+
+[[package]]
+name = "relayer-utils"
+version = "0.4.62-12"
 source = "git+https://github.com/zkemail/relayer-utils#728b8f643a6c9a1e5b400be6407727851cc8c92c"
 dependencies = [
  "anyhow",
@@ -4493,7 +4536,7 @@ dependencies = [
  "prost-wkt",
  "prost-wkt-build",
  "prost-wkt-types",
- "relayer-utils",
+ "relayer-utils 0.4.62-12 (git+https://github.com/zkemail/relayer-utils?rev=728b8f643a6c9a1e5b400be6407727851cc8c92c)",
  "reqwest 0.12.15",
  "serde",
  "slog",
@@ -4506,7 +4549,7 @@ version = "0.1.0"
 source = "git+https://github.com/zkemail/sdk-images?branch=main#e7491d31b4491818f91ed550017a20d142891f17"
 dependencies = [
  "anyhow",
- "relayer-utils",
+ "relayer-utils 0.4.62-12 (git+https://github.com/zkemail/relayer-utils)",
  "reqwest 0.12.15",
  "serde",
  "slog",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,5 @@
 [workspace]
 members = [ "circom", "noir", "sdk-utils"]
-version = "0.1.0"
-edition = "2021"
 resolver = "2"
 
 [workspace.dependencies]

--- a/circom/Cargo.toml
+++ b/circom/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 anyhow = "1.0.90"
 dotenv = "0.15.0"
 tokio = { version = "1.40.0", features = ["full"] }
-relayer-utils = { git = "https://github.com/zkemail/relayer-utils", commit = "728b8f643a6c9a1e5b400be6407727851cc8c92c" }
+relayer-utils = { git = "https://github.com/zkemail/relayer-utils", rev = "728b8f643a6c9a1e5b400be6407727851cc8c92c" }
 slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_warn"] }
 sdk-utils = { git = "https://github.com/zkemail/sdk-images", branch = "main" }
 serde = "1.0.215"

--- a/circom/src/contract.rs
+++ b/circom/src/contract.rs
@@ -123,7 +123,7 @@ pub async fn generate_verifier_contract(tmp_dir: &str) -> Result<()> {
     // Generate the verifier contract
     info!(LOG, "Generating verifier contract");
     run_command(
-        &chunked_snarkjs_path,
+        chunked_snarkjs_path,
         &[
             "zkey",
             "export",

--- a/circom/src/db.rs
+++ b/circom/src/db.rs
@@ -21,18 +21,18 @@ pub async fn update_verifier_contract_address(
     Ok(())
 }
 
-pub async fn update_ptau(pool: &Pool<Postgres>, id: Uuid, ptau: usize) -> Result<()> {
-    let query = r#"
-        UPDATE blueprints
-        SET ptau = $1
-        WHERE id = $2
-    "#;
+// pub async fn update_ptau(pool: &Pool<Postgres>, id: Uuid, ptau: usize) -> Result<()> {
+//     let query = r#"
+//         UPDATE blueprints
+//         SET ptau = $1
+//         WHERE id = $2
+//     "#;
 
-    sqlx::query(query)
-        .bind(ptau as i32)
-        .bind(id)
-        .execute(pool)
-        .await?;
+//     sqlx::query(query)
+//         .bind(ptau as i32)
+//         .bind(id)
+//         .execute(pool)
+//         .await?;
 
-    Ok(())
-}
+//     Ok(())
+// }

--- a/circom/src/main.rs
+++ b/circom/src/main.rs
@@ -9,7 +9,7 @@ use anyhow::Result;
 use contract::{
     create_contract, deploy_verifier_contract, generate_verifier_contract, prepare_contract_data,
 };
-use db::{update_ptau, update_verifier_contract_address};
+use db::update_verifier_contract_address;
 use payload::UploadUrls;
 use rand::Rng;
 use relayer_utils::LOG;
@@ -273,7 +273,7 @@ async fn generate_keys(tmp_dir: &str, ptau: usize) -> Result<()> {
             "--max-semi-space-size=1024",
             "--initial-heap-size=65536",
             "--expose-gc",
-            &chunked_snarkjs_path,
+            chunked_snarkjs_path,
             "groth16",
             "setup",
             "circuit.r1cs",
@@ -287,7 +287,7 @@ async fn generate_keys(tmp_dir: &str, ptau: usize) -> Result<()> {
     // Contribute to chunked zkey
     info!(LOG, "Contributing to chunked zkey");
     run_command(
-        &chunked_snarkjs_path,
+        chunked_snarkjs_path,
         &[
             "zkey",
             "beacon",
@@ -313,7 +313,7 @@ async fn generate_keys(tmp_dir: &str, ptau: usize) -> Result<()> {
     // Export verification key
     info!(LOG, "Exporting verification key");
     run_command(
-        &chunked_snarkjs_path,
+        chunked_snarkjs_path,
         &[
             "zkey",
             "export",

--- a/circom/src/payload.rs
+++ b/circom/src/payload.rs
@@ -1,6 +1,7 @@
 use std::env;
 
 use anyhow::Result;
+use base64::Engine;
 use dotenv::dotenv;
 use relayer_utils::LOG;
 use sdk_utils::Blueprint;
@@ -48,8 +49,8 @@ pub fn load_payload() -> Result<Payload> {
     dotenv().ok();
 
     // Decode the base64-encoded PAYLOAD environment variable
-    let decoded_payload =
-        base64::decode(std::env::var("PAYLOAD").expect("PAYLOAD environment variable not set"))?;
+    let decoded_payload = base64::engine::general_purpose::STANDARD
+        .decode(std::env::var("PAYLOAD").expect("PAYLOAD environment variable not set"))?;
 
     // Convert the decoded bytes to a string
     let payload_str = String::from_utf8(decoded_payload)?;

--- a/circom/src/payload.rs
+++ b/circom/src/payload.rs
@@ -61,19 +61,19 @@ pub fn load_payload() -> Result<Payload> {
     info!(LOG, "Setting ENV variables");
     env::set_var("JSON_LOGGER", "true");
 
-    if payload.private_key != "" {
+    if !payload.private_key.is_empty() {
         env::set_var("PRIVATE_KEY", &payload.private_key);
     }
-    if payload.rpc_url != "" {
+    if !payload.rpc_url.is_empty() {
         env::set_var("RPC_URL", &payload.rpc_url);
     }
     if payload.chain_id != 0 {
-        env::set_var("CHAIN_ID", &payload.chain_id.to_string());
+        env::set_var("CHAIN_ID", payload.chain_id.to_string());
     }
-    if payload.etherscan_api_key != "" {
+    if !payload.etherscan_api_key.is_empty() {
         env::set_var("ETHERSCAN_API_KEY", &payload.etherscan_api_key);
     }
-    if payload.dkim_registry_address != "" {
+    if !payload.dkim_registry_address.is_empty() {
         env::set_var("DKIM_REGISTRY", &payload.dkim_registry_address);
     }
 

--- a/circom/src/template.rs
+++ b/circom/src/template.rs
@@ -52,8 +52,8 @@ pub struct CircuitTemplateInputs {
 impl From<Blueprint> for CircuitTemplateInputs {
     fn from(value: Blueprint) -> Self {
         let circuit_name = value.circuit_name.unwrap_or_else(|| "circuit".to_string());
-        let email_header_max_length = value.email_header_max_length.unwrap_or(1024) as usize;
-        let email_body_max_length = value.email_body_max_length.unwrap_or(2048) as usize;
+        let email_header_max_length = value.email_header_max_length.unwrap_or(1024);
+        let email_body_max_length = value.email_body_max_length.unwrap_or(2048);
         let ignore_body_hash_check = value.ignore_body_hash_check.unwrap_or(false);
         let enable_header_masking = value.enable_header_masking.unwrap_or(false);
         let enable_body_masking = value.enable_body_masking.unwrap_or(false);
@@ -67,7 +67,7 @@ impl From<Blueprint> for CircuitTemplateInputs {
             for regex in decomposed_regexes {
                 let name = regex.name.clone();
                 let uppercased_name = name.to_uppercase();
-                let max_length = regex.max_length as usize;
+                let max_length = regex.max_length;
                 let regex_circuit_name = format!("{}Regex", regex.name);
 
                 // Determine location and its max length
@@ -157,10 +157,10 @@ impl From<Blueprint> for CircuitTemplateInputs {
         let external_inputs: Vec<ExternalInputEntry> = external_inputs_data
             .iter()
             .map(|input| {
-                let signal_length = compute_signal_length(input.max_length as usize);
+                let signal_length = compute_signal_length(input.max_length);
                 ExternalInputEntry {
                     name: input.name.clone(),
-                    max_length: input.max_length as usize,
+                    max_length: input.max_length,
                     signal_length,
                 }
             })

--- a/noir/Cargo.toml
+++ b/noir/Cargo.toml
@@ -11,7 +11,7 @@ serde_json = "1.0.133"
 tera = "1.20.0"
 tokio = { version = "1.44.2", features = ["full"] }
 sqlx = { version = "0.8.2", features = ["postgres", "runtime-tokio", "migrate", "uuid", "time", "chrono", "runtime-tokio-rustls"] }
-relayer-utils = { git = "https://github.com/zkemail/relayer-utils", commit = "728b8f643a6c9a1e5b400be6407727851cc8c92c" }
+relayer-utils = { git = "https://github.com/zkemail/relayer-utils", rev = "728b8f643a6c9a1e5b400be6407727851cc8c92c" }
 sdk-utils = { workspace = true }
 slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_warn"] }
 zk-regex-compiler = { package = "compiler", git = "https://github.com/zkemail/zk-regex", branch = "feat/new-compiler" }

--- a/sdk-utils/Cargo.toml
+++ b/sdk-utils/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.90"
-relayer-utils = { git = "https://github.com/zkemail/relayer-utils", commit = "728b8f643a6c9a1e5b400be6407727851cc8c92c" }
+relayer-utils = { git = "https://github.com/zkemail/relayer-utils", rev = "728b8f643a6c9a1e5b400be6407727851cc8c92c" }
 slog = { version = "2.7.0", features = ["max_level_trace", "release_max_level_warn"] }
 reqwest = { version = "0.12.8", features = ["json"] }
 serde = {version = "1.0.214", features = ["derive"]}


### PR DESCRIPTION
* removed unused manifest keys
* fixed relayer utils dep setting (`commit` to `rev` in `Cargo.toml`)
* `circom` fmt and clippy
* fixed `circom` build warnings
