### PR TITLE
chore: cargo lock update

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4586,7 +4586,7 @@ dependencies = [
  "prost-wkt",
  "prost-wkt-build",
  "prost-wkt-types",
- "relayer-utils 0.4.62-12 (git+https://github.com/zkemail/relayer-utils)",
+ "relayer-utils 0.4.62-12 (git+https://github.com/zkemail/relayer-utils?rev=728b8f643a6c9a1e5b400be6407727851cc8c92c)",
  "reqwest 0.12.15",
  "serde",
  "slog",


### PR DESCRIPTION
## What?
Updating `Cargo.lock`, because it did not reflect the correct package version for the `relayer-utils` dependency.

## Why?
It was not updated (or missed during rebase) after setting `rev` to a specific commit hash.