### PR TITLE
feat: add support for 1024-bit RSA keys in Noir circuits

### DIFF
--- a/noir/src/circuit_generator.rs
+++ b/noir/src/circuit_generator.rs
@@ -39,6 +39,8 @@ pub fn generate_circuit(circuit_template_input: CircuitTemplateInputs) -> Result
     context.insert("external_inputs", &circuit_template_input.external_inputs);
     context.insert("output_signals", &circuit_template_input.output_signals);
     context.insert("output_args", &circuit_template_input.output_args);
+    context.insert("key_bits", &circuit_template_input.key_bits);
+    context.insert("key_limbs_constant", &circuit_template_input.key_limbs_constant);
 
     let circuit = tera.render("template.nr.tera", &context)?;
 

--- a/noir/src/filesystem.rs
+++ b/noir/src/filesystem.rs
@@ -15,13 +15,35 @@ pub struct ProductionFileUploader;
 
 impl FileUploader for ProductionFileUploader {
     async fn upload_files(&self, upload_urls: UploadUrls) -> Result<()> {
-        upload_to_url(&upload_urls.circuit, "./tmp/circuit.zip", "application/zip").await?;
+        // 1024-bit artifacts
         upload_to_url(
-            &upload_urls.circuit_json,
-            "./tmp/target/sdk_noir.json",
+            &upload_urls.circuit_1024,
+            "./tmp/circuit_1024.zip",
+            "application/zip",
+        )
+        .await?;
+        upload_to_url(
+            &upload_urls.circuit_json_1024,
+            "./tmp/target/sdk_noir_1024.json",
             "application/json",
         )
         .await?;
+
+        // 2048-bit artifacts
+        upload_to_url(
+            &upload_urls.circuit_2048,
+            "./tmp/circuit_2048.zip",
+            "application/zip",
+        )
+        .await?;
+        upload_to_url(
+            &upload_urls.circuit_json_2048,
+            "./tmp/target/sdk_noir_2048.json",
+            "application/json",
+        )
+        .await?;
+
+        // Shared regex graphs
         upload_to_url(
             &upload_urls.regex_graphs,
             "./tmp/regex_graphs.zip",
@@ -79,18 +101,32 @@ pub async fn compile_circuit() -> Result<()> {
     Ok(())
 }
 
-/// Cleans up after compilation and zips the circuit files
-pub async fn cleanup() -> Result<()> {
-    info!(LOG, "Cleaning up");
+/// Cleans up after multi-key compilation and zips both circuit variants
+/// Takes the circuit source code for each key size to create separate zips
+pub async fn cleanup_multi_key(circuit_1024: &str, circuit_2048: &str) -> Result<()> {
+    info!(LOG, "Cleaning up multi-key compilation");
 
-    info!(LOG, "Zipping circuit");
+    // Write 1024-bit circuit and zip it
+    info!(LOG, "Zipping 1024-bit circuit");
+    std::fs::write("./tmp/src/main.nr", circuit_1024)?;
     run_command(
         "zip",
-        &["-r", "circuit.zip", "src", "Nargo.toml"],
+        &["-r", "circuit_1024.zip", "src", "Nargo.toml"],
         Some("tmp"),
     )
     .await?;
 
+    // Write 2048-bit circuit and zip it
+    info!(LOG, "Zipping 2048-bit circuit");
+    std::fs::write("./tmp/src/main.nr", circuit_2048)?;
+    run_command(
+        "zip",
+        &["-r", "circuit_2048.zip", "src", "Nargo.toml"],
+        Some("tmp"),
+    )
+    .await?;
+
+    // Zip regex graphs (shared)
     info!(LOG, "Zipping regex graphs");
     run_command(
         "zip",

--- a/noir/src/handlers.rs
+++ b/noir/src/handlers.rs
@@ -7,15 +7,17 @@ use slog::info;
 
 // Import from the crate root
 use crate::circuit_generator::generate_circuit;
-use crate::filesystem::{FileUploader, ProductionFileUploader, cleanup, compile_circuit, setup};
+use crate::filesystem::{FileUploader, ProductionFileUploader, cleanup_multi_key, compile_circuit, setup};
 use crate::models::CircuitTemplateInputs;
 use crate::regex_generator::generate_regex_circuits;
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct UploadUrls {
-    pub circuit: String,
-    pub circuit_json: String,
+    pub circuit_1024: String,
+    pub circuit_2048: String,
+    pub circuit_json_1024: String,
+    pub circuit_json_2048: String,
     pub regex_graphs: String,
 }
 
@@ -54,22 +56,37 @@ async fn process_circuit(payload: Payload, uploader: impl FileUploader) -> Resul
     // Extract blueprint
     let blueprint = payload.blueprint;
 
-    // Generate regex circuits
+    // Generate regex circuits (shared between both key sizes)
     generate_regex_circuits(&blueprint.decomposed_regexes)?;
 
-    // Generate main circuit from template
-    let circuit_template_inputs = CircuitTemplateInputs::from(blueprint);
-
-    let circuit = generate_circuit(circuit_template_inputs)?;
-
-    // Write the circuit to a file
-    let circuit_path = "./tmp/src/main.nr";
-    std::fs::write(circuit_path, circuit)?;
-
-    // Compile and clean up
+    // Generate and compile 1024-bit circuit
+    info!(LOG, "Generating 1024-bit circuit");
+    let inputs_1024 = CircuitTemplateInputs::from_blueprint_with_key_size(&blueprint, 1024);
+    let circuit_1024 = generate_circuit(inputs_1024)?;
+    std::fs::write("./tmp/src/main.nr", &circuit_1024)?;
     compile_circuit().await?;
 
-    cleanup().await?;
+    // Move 1024-bit artifacts to specific names
+    std::fs::rename(
+        "./tmp/target/sdk_noir.json",
+        "./tmp/target/sdk_noir_1024.json",
+    )?;
+
+    // Generate and compile 2048-bit circuit
+    info!(LOG, "Generating 2048-bit circuit");
+    let inputs_2048 = CircuitTemplateInputs::from_blueprint_with_key_size(&blueprint, 2048);
+    let circuit_2048 = generate_circuit(inputs_2048)?;
+    std::fs::write("./tmp/src/main.nr", &circuit_2048)?;
+    compile_circuit().await?;
+
+    // Move 2048-bit artifacts to specific names
+    std::fs::rename(
+        "./tmp/target/sdk_noir.json",
+        "./tmp/target/sdk_noir_2048.json",
+    )?;
+
+    // Cleanup and zip both circuits
+    cleanup_multi_key(&circuit_1024, &circuit_2048).await?;
 
     // Upload files
     uploader.upload_files(payload.upload_urls).await?;
@@ -157,8 +174,10 @@ mod tests {
         };
 
         let upload_urls = UploadUrls {
-            circuit: "".to_string(),
-            circuit_json: "".to_string(),
+            circuit_1024: "".to_string(),
+            circuit_2048: "".to_string(),
+            circuit_json_1024: "".to_string(),
+            circuit_json_2048: "".to_string(),
             regex_graphs: "".to_string(),
         };
 
@@ -267,8 +286,10 @@ mod tests {
         };
 
         let upload_urls = UploadUrls {
-            circuit: "".to_string(),
-            circuit_json: "".to_string(),
+            circuit_1024: "".to_string(),
+            circuit_2048: "".to_string(),
+            circuit_json_1024: "".to_string(),
+            circuit_json_2048: "".to_string(),
             regex_graphs: "".to_string(),
         };
 
@@ -402,8 +423,10 @@ mod tests {
         };
 
         let upload_urls = UploadUrls {
-            circuit: "".to_string(),
-            circuit_json: "".to_string(),
+            circuit_1024: "".to_string(),
+            circuit_2048: "".to_string(),
+            circuit_json_1024: "".to_string(),
+            circuit_json_2048: "".to_string(),
             regex_graphs: "".to_string(),
         };
 
@@ -500,8 +523,10 @@ mod tests {
         };
 
         let upload_urls = UploadUrls {
-            circuit: "".to_string(),
-            circuit_json: "".to_string(),
+            circuit_1024: "".to_string(),
+            circuit_2048: "".to_string(),
+            circuit_json_1024: "".to_string(),
+            circuit_json_2048: "".to_string(),
             regex_graphs: "".to_string(),
         };
 
@@ -600,8 +625,10 @@ mod tests {
         };
 
         let upload_urls = UploadUrls {
-            circuit: "".to_string(),
-            circuit_json: "".to_string(),
+            circuit_1024: "".to_string(),
+            circuit_2048: "".to_string(),
+            circuit_json_1024: "".to_string(),
+            circuit_json_2048: "".to_string(),
             regex_graphs: "".to_string(),
         };
 

--- a/noir/src/handlers.rs
+++ b/noir/src/handlers.rs
@@ -59,6 +59,18 @@ async fn process_circuit(payload: Payload, uploader: impl FileUploader) -> Resul
     // Generate regex circuits (shared between both key sizes)
     generate_regex_circuits(&blueprint.decomposed_regexes)?;
 
+    // Generate separate circuits for 1024-bit and 2048-bit RSA keys.
+    //
+    // Why two circuits instead of one with conditional logic?
+    // - Noir circuits are compile-time fixed; any conditional branching on key size
+    //   would still compile all code paths and incur the constraint cost of both sizes
+    // - Two specialized circuits are more efficient since each only contains the
+    //   constraints needed for its specific key size
+    // - The zkemail library exports different array sizes (KEY_LIMBS_1024=9 vs
+    //   KEY_LIMBS_2048=18) that must be known at compile time for type safety
+    // - This approach lets provers select the appropriate circuit based on the
+    //   actual DKIM key size of the email they're proving
+
     // Generate and compile 1024-bit circuit
     info!(LOG, "Generating 1024-bit circuit");
     let inputs_1024 = CircuitTemplateInputs::from_blueprint_with_key_size(&blueprint, 1024);

--- a/noir/src/models.rs
+++ b/noir/src/models.rs
@@ -4,7 +4,7 @@ use serde::Serialize;
 
 /// Represents a single decomposed regex, along with computed fields
 /// used for generating the circuit template.
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct RegexEntry {
     pub name: String,
     pub max_match_length: usize,
@@ -20,7 +20,7 @@ pub struct RegexEntry {
 }
 
 /// Represents an external input to the circuit, along with computed fields.
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct ExternalInputEntry {
     pub name: String,
     pub max_length: usize,
@@ -28,7 +28,7 @@ pub struct ExternalInputEntry {
 }
 
 /// A struct that holds all the data required to render the circuit template.
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct CircuitTemplateInputs {
     pub circuit_name: String,
     pub email_header_max_length: usize,
@@ -41,6 +41,26 @@ pub struct CircuitTemplateInputs {
     pub external_inputs: Vec<ExternalInputEntry>,
     pub output_args: String,
     pub output_signals: String,
+    /// RSA key size in bits (1024 or 2048)
+    pub key_bits: u32,
+    /// Constant name for the key limbs ("KEY_LIMBS_1024" or "KEY_LIMBS_2048")
+    pub key_limbs_constant: String,
+}
+
+impl CircuitTemplateInputs {
+    /// Create CircuitTemplateInputs from Blueprint with a specific key size
+    pub fn from_blueprint_with_key_size(blueprint: &Blueprint, key_bits: u32) -> Self {
+        let mut inputs = Self::from(blueprint.clone());
+        inputs.key_bits = key_bits;
+        // Use numeric values for key limbs as the constants may not be publicly exported
+        // KEY_LIMBS_1024 = 9, KEY_LIMBS_2048 = 18
+        inputs.key_limbs_constant = if key_bits == 1024 {
+            "9".to_string()
+        } else {
+            "18".to_string()
+        };
+        inputs
+    }
 }
 
 impl From<Blueprint> for CircuitTemplateInputs {
@@ -181,6 +201,9 @@ impl From<Blueprint> for CircuitTemplateInputs {
             external_inputs,
             output_args,
             output_signals,
+            // Default to 2048 for backwards compatibility
+            key_bits: 2048,
+            key_limbs_constant: "18".to_string(),
         }
     }
 }

--- a/noir/templates/template.nr.tera
+++ b/noir/templates/template.nr.tera
@@ -4,15 +4,17 @@ mod {{ regex.regex_circuit_name }};
 use poseidon::poseidon;
 use std::{collections::bounded_vec::BoundedVec, hash::pedersen_hash};
 use zkemail::{
-    dkim::RSAPubkey, hash::poseidon_large, headers::body_hash::get_body_hash, KEY_LIMBS_2048,
+    dkim::RSAPubkey,
+    {% if key_bits == 2048 %}hash::poseidon_large,{% endif %}
+    headers::body_hash::get_body_hash,
     partial_hash::partial_sha256_var_end, remove_soft_line_breaks::remove_soft_line_breaks,
     masking::mask_text, Sequence, utils::pack_bytes,
 };
 
 fn main(
     header: BoundedVec<u8, {{ email_header_max_length }}>,
-    pubkey: RSAPubkey<KEY_LIMBS_2048>,
-    signature: [Field; KEY_LIMBS_2048],
+    pubkey: RSAPubkey<{{ key_limbs_constant }}>,
+    signature: [Field; {{ key_limbs_constant }}],
     prover_address: [Field; 1],
 {% if enable_header_masking %}
     header_mask: [bool; {{ email_header_max_length }}],
@@ -81,7 +83,11 @@ fn main(
 {% endif %}
 
     let pubkey_hash = pubkey.hash();
+{% if key_bits == 2048 %}
     let email_nullifier = poseidon::bn254::hash_1([poseidon_large(signature)]);
+{% else %}
+    let email_nullifier = poseidon::bn254::hash_1([poseidon::bn254::hash_9(signature)]);
+{% endif %}
 
 {% if enable_header_masking %}
     // Apply mask using mask_text function


### PR DESCRIPTION
## Summary

  - Add support for generating both 1024-bit and 2048-bit RSA key circuits in Noir
  - Compile and upload artifacts for both key sizes in a single blueprint compilation
  - Update template to use dynamic key limbs and conditional poseidon hashing based on key size

  ## Changes

  - **models.rs**: Add `key_bits` and `key_limbs_constant` fields to `CircuitTemplateInputs`, new `from_blueprint_with_key_size()` constructor
  - **circuit_generator.rs**: Pass key size fields to Tera template context
  - **handlers.rs**: Generate and compile both 1024 and 2048-bit circuits sequentially, update `UploadUrls` to include separate URLs for each variant
  - **filesystem.rs**: New `cleanup_multi_key()` function to zip both circuit variants, update upload logic for 4 artifacts (2 circuits + 2 JSONs + shared regex graphs)
  - **template.nr.tera**: Use dynamic `key_limbs_constant`, conditional import of `poseidon_large` (only for 2048-bit), conditional nullifier hash function

  ## Test plan

  - [x] Verify 1024-bit circuit compiles successfully
  - [x] Verify 2048-bit circuit compiles successfully
  - [x] Verify both artifacts are uploaded with correct names
  - [x] Run existing tests with `cargo test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added dual key size support (1024-bit and 2048-bit) with separate circuit artifacts and configuration files for each variant.

* **Improvements**
  * Enhanced circuit generation to dynamically configure parameters and artifacts based on selected key size.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->