### PR TITLE
fix: upload circuit artifacts before contract deployment + stream command output

### DIFF
--- a/circom/src/main.rs
+++ b/circom/src/main.rs
@@ -153,15 +153,18 @@ async fn main() -> Result<()> {
     )
     .await?;
 
+    // Cleanup (compress/zip artifacts) and upload to GCS BEFORE deployment.
+    // This ensures all circuit artifacts are safely persisted even if contract deployment fails,
+    // so we don't lose hours of compute on a deployment-only failure.
+    cleanup().await?;
+
+    upload_files(payload.upload_urls).await?;
+
     let contract_address = deploy_verifier_contract(payload.chain_id).await?;
 
     info!(LOG, "Contract deployed at: {}", contract_address);
 
-    cleanup().await?;
-
     update_verifier_contract_address(&pool, &blueprint.id, &contract_address).await?;
-
-    upload_files(payload.upload_urls).await?;
 
     Ok(())
 }

--- a/sdk-utils/src/command.rs
+++ b/sdk-utils/src/command.rs
@@ -104,15 +104,32 @@ pub async fn run_command_and_return_output(
         cmd.current_dir(directory);
     }
 
-    let output = cmd.output().expect("failed to execute process");
+    // Stream stdout through slog for real-time log visibility.
+    // Let stderr inherit so it goes directly to the pod output immediately.
+    let mut child = cmd
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .spawn()
+        .expect("failed to execute process");
 
-    if !output.status.success() {
+    let mut output_lines = Vec::new();
+    if let Some(stdout) = child.stdout.take() {
+        let reader = BufReader::new(stdout);
+        for line in reader.lines() {
+            let line = line?;
+            info!(LOG, "Command output"; "line" => &line);
+            output_lines.push(line);
+        }
+    }
+
+    let status = child.wait()?;
+    if !status.success() {
         return Err(anyhow!(
-            "Command `{}` failed: {}",
+            "Command `{}` failed with status: {}",
             command,
-            String::from_utf8_lossy(&output.stderr)
+            status
         ));
     }
 
-    Ok(String::from_utf8_lossy(&output.stdout).to_string())
+    Ok(output_lines.join("\n"))
 }


### PR DESCRIPTION
## Summary

- **Upload before deploy**: Reordered `circom/src/main.rs` so `cleanup()` and `upload_files()` run *before* `deploy_verifier_contract()`. Previously, a failed contract deployment meant all GCS artifacts (circuit.wasm, zkeys, vk.json, etc.) were lost after 75+ minutes of compute. Now they are safely persisted to GCS regardless of deployment outcome.

- **Streaming command output**: Replaced buffered `cmd.output()` in `run_command_and_return_output` with a streaming approach (BufReader over piped stdout + `Stdio::inherit()` for stderr). Previously, forge script output and errors were silently swallowed until the process exited — making it impossible to debug failed deployments. Now all output is logged via slog in real-time to pod logs.

## Test plan

- [ ] Trigger a Circom blueprint compilation
- [ ] Verify circuit artifacts appear in GCS before contract deployment completes
- [ ] Verify forge script output is visible line-by-line in pod logs
- [ ] Verify artifacts are preserved if contract deployment fails