### PR TITLE
fix: update Barretenberg bbup install URL (master → next)

### DIFF
--- a/noir/Dockerfile
+++ b/noir/Dockerfile
@@ -26,7 +26,7 @@ ENV PATH="/root/.nargo/bin:$PATH"
 RUN noirup --version 1.0.0-beta.5
 
 # Install Barrentenberg
-RUN curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/master/barretenberg/bbup/install | bash
+RUN curl -L https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/next/barretenberg/bbup/install | bash
 ENV PATH="/root/.bb:$PATH"
 RUN bbup --version 0.84.0
 


### PR DESCRIPTION
## Summary

- Fixes Noir Docker build failure on Cloud Build caused by a 404 on the Barretenberg `bbup` install script URL

## Root cause

The `AztecProtocol/aztec-packages` repo renamed their default branch from `master` to `next`. The Dockerfile was still referencing:

```
https://raw.githubusercontent.com/AztecProtocol/aztec-packages/refs/heads/master/barretenberg/bbup/install
```

This URL now returns a `404` response. When piped to `bash`, it tries to execute `404:` as a command:

```
bash: line 1: 404:: command not found
The command '/bin/sh -c curl -L ... | bash' returned a non-zero code: 127
```

Cloud Build log: `9d2828d1-f306-4dad-8b77-90a642ecee56`

## Fix

Change `master` → `next` in the bbup install URL (line 29 of `noir/Dockerfile`).

## Test plan

- [ ] Merge and verify the Noir Cloud Build succeeds
- [ ] Verify `bbup --version 0.84.0` still installs correctly from the `next` branch