### PR TITLE
fix: run yarn commands in contracts directory

### DIFF
--- a/circom/src/contract.rs
+++ b/circom/src/contract.rs
@@ -259,11 +259,14 @@ pub async fn deploy_verifier_contract(chain_id: u32) -> Result<String> {
         ("build", "deploy", "verify")
     };
 
+    info!(LOG, "Installing contract dependencies");
+    run_command("yarn", &["install"], Some("contracts")).await?;
+
     info!(LOG, "Building contracts");
-    run_command("yarn", &[build_cmd], None).await?;
+    run_command("yarn", &[build_cmd], Some("contracts")).await?;
 
     info!(LOG, "Deploying contracts");
-    let output = run_command_and_return_output("yarn", &[deploy_cmd], None).await?;
+    let output = run_command_and_return_output("yarn", &[deploy_cmd], Some("contracts")).await?;
 
     // Parse the output to extract addresses
     let re = Regex::new(r"(DKIM_REGISTRY|GROTH16_VERIFIER|ZK_EMAIL_VERIFIER): (0x[a-fA-F0-9]{40})")
@@ -281,7 +284,7 @@ pub async fn deploy_verifier_contract(chain_id: u32) -> Result<String> {
 
     if should_verify {
         info!(LOG, "Verifying contracts");
-        if let Err(e) = run_command("yarn", &[verify_cmd], None).await {
+        if let Err(e) = run_command("yarn", &[verify_cmd], Some("contracts")).await {
             info!(
                 LOG,
                 "Contract verification failed: {}. Continuing without verification.", e


### PR DESCRIPTION
## Summary

- PR #46 (`chore: contracts cleanup`) moved contract files from `circom/` root into `circom/contracts/` subdirectory but did not update `contract.rs` to pass the correct working directory
- `yarn build`, `yarn deploy`, and `yarn verify` were running in `/root/circom/circom/` where `package.json` has no `build`/`deploy` scripts, causing `error Command "build" not found`
- This bug was latent since March 3 — it only surfaced now because the previous deployed Docker image (`ec3e098`, Nov 2025) predated PR #46
- Also adds `yarn install` for the `contracts/` directory since it has its own `package.json` and `yarn.lock` (separate from root, needed for `forge-std` dependency)

## Changes

- `deploy_verifier_contract()` in `contract.rs`: pass `Some("contracts")` as the working directory for all `yarn` commands (install, build, deploy, verify)

## Test plan

- [ ] Merge and trigger a new Docker image build
- [ ] Deploy the new image to dev
- [ ] Retrigger compilation for blueprint `a4613e68-a264-4f3e-ae2f-423dd263d2a1`
- [ ] Verify `yarn build` (forge build) succeeds in the contracts/ directory
- [ ] Verify `yarn deploy` (forge script) runs correctly