### PR TITLE
fix: write generated contracts to contracts/src/ for forge build

### DIFF
--- a/circom/src/contract.rs
+++ b/circom/src/contract.rs
@@ -259,11 +259,14 @@ pub async fn deploy_verifier_contract(chain_id: u32) -> Result<String> {
         ("build", "deploy", "verify")
     };
 
+    info!(LOG, "Installing contract dependencies");
+    run_command("yarn", &["install"], Some("contracts")).await?;
+
     info!(LOG, "Building contracts");
-    run_command("yarn", &[build_cmd], None).await?;
+    run_command("yarn", &[build_cmd], Some("contracts")).await?;
 
     info!(LOG, "Deploying contracts");
-    let output = run_command_and_return_output("yarn", &[deploy_cmd], None).await?;
+    let output = run_command_and_return_output("yarn", &[deploy_cmd], Some("contracts")).await?;
 
     // Parse the output to extract addresses
     let re = Regex::new(r"(DKIM_REGISTRY|GROTH16_VERIFIER|ZK_EMAIL_VERIFIER): (0x[a-fA-F0-9]{40})")
@@ -281,7 +284,7 @@ pub async fn deploy_verifier_contract(chain_id: u32) -> Result<String> {
 
     if should_verify {
         info!(LOG, "Verifying contracts");
-        if let Err(e) = run_command("yarn", &[verify_cmd], None).await {
+        if let Err(e) = run_command("yarn", &[verify_cmd], Some("contracts")).await {
             info!(
                 LOG,
                 "Contract verification failed: {}. Continuing without verification.", e

--- a/circom/src/main.rs
+++ b/circom/src/main.rs
@@ -23,8 +23,8 @@ use sqlx::postgres::PgPoolOptions;
 use template::{generate_circuit, generate_regex_circuits, CircuitTemplateInputs};
 
 /// All contract files bundled into the downloadable zip, relative to `contracts/`.
-/// Files listed here but NOT in `GENERATED_CONTRACT_FILES` are copied from the
-/// source `contracts/` directory; generated files are produced by templates / snarkjs.
+/// Some files are static (checked into the repo), others in `GENERATED_CONTRACT_FILES`
+/// are produced at runtime by templates / snarkjs into `contracts/src/`.
 const CONTRACT_BUNDLE_FILES: &[&str] = &[
     ".env.example",
     "README.md",
@@ -46,6 +46,7 @@ const CONTRACT_BUNDLE_FILES: &[&str] = &[
     "hh-utils/require-env.ts",
 ];
 
+#[cfg(test)]
 const GENERATED_CONTRACT_FILES: &[&str] = &[
     "src/Groth16Verifier.sol",
     "src/ZKEmailVerifier.sol",
@@ -138,8 +139,8 @@ async fn main() -> Result<()> {
 
     create_zkemail_verifier_and_interface_at_paths(
         &contract_data,
-        "tmp/contracts/src/ZKEmailVerifier.sol",
-        "tmp/contracts/src/interfaces/IGroth16Verifier.sol",
+        "contracts/src/ZKEmailVerifier.sol",
+        "contracts/src/interfaces/IGroth16Verifier.sol",
     )?;
 
     let chunked_snarkjs_path = "./node_modules/.bin/snarkjs";
@@ -149,7 +150,7 @@ async fn main() -> Result<()> {
         "tmp",
         chunked_snarkjs_path,
         "circuit.zkey",
-        "tmp/contracts/src/Groth16Verifier.sol",
+        "contracts/src/Groth16Verifier.sol",
     )
     .await?;
 
@@ -196,10 +197,10 @@ async fn setup() -> Result<()> {
     }
     fs::create_dir_all(&regex_path)?;
 
-    // Ensure tmp/contracts/src and interfaces exist for generated contract files
-    let tmp_contracts_src = tmp_path.join("contracts/src");
-    fs::create_dir_all(&tmp_contracts_src)?;
-    fs::create_dir_all(tmp_contracts_src.join("interfaces"))?;
+    // Ensure contracts/src and interfaces exist for generated contract files
+    let contracts_src = Path::new("contracts/src");
+    fs::create_dir_all(&contracts_src)?;
+    fs::create_dir_all(contracts_src.join("interfaces"))?;
 
     run_command("cp", &["package.json", "./tmp"], None).await?;
     Ok(())
@@ -436,13 +437,9 @@ async fn generate_keys(tmp_dir: &str, ptau: usize) -> Result<()> {
 async fn cleanup() -> Result<()> {
     info!(LOG, "Cleaning up");
 
-    // Copy non-generated contract files into tmp/contracts (generated files are
-    // already written there by the template / snarkjs steps above).
+    // Copy all contract files (source + generated) into tmp/contracts for zipping.
     let contracts_tmp_dir = Path::new("tmp").join("contracts");
     for file in CONTRACT_BUNDLE_FILES {
-        if GENERATED_CONTRACT_FILES.contains(file) {
-            continue;
-        }
         let src = Path::new("contracts").join(file);
         let dst = contracts_tmp_dir.join(file);
         if let Some(parent) = dst.parent() {


### PR DESCRIPTION
## Summary

Follow-up to PR #52. The `yarn build` (forge build) fix correctly changed the working directory to `contracts/`, but `forge build` still fails because the generated Solidity files (`Groth16Verifier.sol`, `ZKEmailVerifier.sol`, `IGroth16Verifier.sol`) were being written to `tmp/contracts/src/` instead of `contracts/src/`.

**Error from GCP Cloud Logging:**
```
Error (6275): Source "src/Groth16Verifier.sol" not found: File not found.
  Searched the following locations: "/root/circom/circom/contracts"
Error (6275): Source "src/ZKEmailVerifier.sol" not found: File not found.
  Searched the following locations: "/root/circom/circom/contracts"
```

## Changes

- Write generated contract files to `contracts/src/` instead of `tmp/contracts/src/`
- Setup now creates `contracts/src/` directories (not `tmp/contracts/src/`)
- Cleanup copies all contract files to `tmp/contracts/` for zipping (no longer skips generated files since they now live in `contracts/`)

## Root cause

PR #46 moved contracts from the circom root into `contracts/` subdirectory. The template generation paths were updated to write to `tmp/contracts/src/`, but `forge build` runs in `contracts/` and expects sources in `contracts/src/`. These two paths don't overlap.

## Test plan

- [ ] Merge and trigger Docker image build
- [ ] Deploy new image to dev
- [ ] Retrigger compilation for blueprint `a4613e68-a264-4f3e-ae2f-423dd263d2a1`
- [ ] Verify `forge build` finds `Groth16Verifier.sol` and `ZKEmailVerifier.sol`
- [ ] Verify full pipeline completes (compile → zkey → contracts → deploy → upload)