### PR TITLE
fix: add jq to Circom Dockerfile for contract verification

### DIFF
--- a/circom/Dockerfile
+++ b/circom/Dockerfile
@@ -34,7 +34,8 @@ RUN apt update && \
     protobuf-compiler \
     libprotobuf-dev \
     zip \
-    unzip && \
+    unzip \
+    jq && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Python version using pyenv


### PR DESCRIPTION
## Summary
- Adds `jq` to the Circom Dockerfile apt install list
- Fixes `verify-zk-email-verifier.sh` failing with `jq: command not found` (exit code 127) during Etherscan contract verification after deployment

## Context
During the successful compilation of blueprint `a4613e68-a264-4f3e-ae2f-423dd263d2a1`, the contract deployed to Sepolia (`0xd7cD5cec46715660CB5097c1Ec04BA7b9fc6408E`) but Etherscan verification failed because `jq` was missing from the Docker image. The verification failure is handled gracefully (logged and skipped), but having `jq` available will let verification succeed.

## Test plan
- [ ] CI Docker image builds successfully with `jq` included
- [ ] Trigger a blueprint compilation and verify the Etherscan verification step passes