### PR TITLE
feat: update zkemail.nr to v2.0.0 for [Field; 2] pubkey hash

### DIFF
--- a/circom/Dockerfile
+++ b/circom/Dockerfile
@@ -34,7 +34,8 @@ RUN apt update && \
     protobuf-compiler \
     libprotobuf-dev \
     zip \
-    unzip && \
+    unzip \
+    jq && \
     rm -rf /var/lib/apt/lists/*
 
 # Install Python version using pyenv

--- a/noir/Nargo.toml.txt
+++ b/noir/Nargo.toml.txt
@@ -5,6 +5,6 @@ authors = []
 compiler_version = ">=1.0.0"
 
 [dependencies]
-zkemail = { tag = "v.1.0.1-beta.5", git = "https://github.com/zkemail/zkemail.nr", directory = "lib" }
+zkemail = { tag = "v2.0.0", git = "https://github.com/zkemail/zkemail.nr", directory = "lib" }
 zkregex = { tag = "2.2.0", git = "https://github.com/zkemail/zk-regex", directory = "noir" }
 poseidon = { tag = "v0.1.0", git = "https://github.com/noir-lang/poseidon" }

--- a/noir/templates/template.nr.tera
+++ b/noir/templates/template.nr.tera
@@ -50,7 +50,7 @@ fn main(
     {{ regex.name }}_capture_group_start_indices: [Field; {{ regex.num_public_parts }}],
 {% endif %}
 {% endfor %}
-) -> pub (Field, Field, Field, Field, [Field; 1] {{ output_args }}) {
+) -> pub (Field, Field, Field, Field, Field, [Field; 1] {{ output_args }}) {
     // check the body and header lengths are within bounds
     assert(header.len() <= {{ email_header_max_length }});
 {% if not ignore_body_hash_check %}
@@ -130,5 +130,5 @@ fn main(
 {% endif %}
 {% endfor %}
 
-    (pubkey_hash, email_nullifier, header_hash[0], header_hash[1], prover_address{{ output_signals }})
+    (pubkey_hash[0], pubkey_hash[1], email_nullifier, header_hash[0], header_hash[1], prover_address{{ output_signals }})
 }


### PR DESCRIPTION
## Summary
- Update `zkemail` dependency in `Nargo.toml.txt` from `v.1.0.1-beta.5` to `v2.0.0`
- Update `template.nr.tera` output tuple to include both `pubkey_hash[0]` (modulus hash) and `pubkey_hash[1]` (redc hash) fields, matching the new `RSAPubkey.hash() -> [Field; 2]` return type

Part of [REG-670](https://linear.app/zk-email/issue/REG-670): Update zkemail.nr consumers for v2.0.0 (redc binding & hash changes)

## Test plan
- [x] All 5 `cargo test --lib -- --test-threads=1` pass (XAccountExportData, AppleKYC, Sp1Residency, Kraken KYC, SubjectExtract)
- [x] Circuits compile with `nargo` against `zkemail.nr` v2.0.0 for both 1024-bit and 2048-bit RSA keys
- [ ] E2E: compile a blueprint through conductor and verify circuit output signature