### PR TITLE
fix: correct Ignition deployed addresses path

### DIFF
--- a/circom/src/contract.rs
+++ b/circom/src/contract.rs
@@ -304,7 +304,7 @@ pub async fn deploy_verifier_contract(chain_id: u32) -> Result<String> {
 
 fn read_ignition_deployed_address(chain_id: u32) -> Result<Option<String>> {
     let path = format!(
-        "tmp/contracts/hh-ignition/deployments/chain-{}/deployed_addresses.json",
+        "contracts/hh-ignition/deployments/chain-{}/deployed_addresses.json",
         chain_id
     );
 


### PR DESCRIPTION
## Summary
- Fix incorrect file path in `read_ignition_deployed_address` that was looking for Hardhat Ignition output at `tmp/contracts/hh-ignition/deployments/` instead of `contracts/hh-ignition/deployments/`
- Hardhat runs from the `contracts/` directory (via `run_command_and_return_output(..., Some("contracts"))`), so Ignition writes its output relative to that directory, not under `tmp/`
- This was causing every Circom compilation to fail at the contract deployment step even though the deployment itself was succeeding

## Root cause
PR #54 introduced the Hardhat Ignition deployment path but the `read_ignition_deployed_address` function had an incorrect `tmp/` prefix carried over from the old directory structure.

## Test plan
- [ ] Merge and wait for Docker image rebuild
- [ ] Trigger Circom compilation for blueprint `312c36bd-6ce7-4d0f-a62a-b41aa55372fb` 
- [ ] Verify compilation completes successfully with contract address in the database