### PR TITLE
feat(circom): PolkaVM Ignition reliability improvements and env-based RPC/accounts

### DIFF
--- a/circom/contracts/README.md
+++ b/circom/contracts/README.md
@@ -43,13 +43,15 @@ Once you have a `DKIMRegistry` address (from either 1 or 2), pass that address i
 
 Copy `.env.example` to `.env` and fill in the values:
 
-| Variable            | Required                      | Description                                                                                |
-| ------------------- | ----------------------------- | ------------------------------------------------------------------------------------------ |
-| `PRIVATE_KEY`       | Yes                           | EOA private key used to broadcast transactions.                                            |
-| `DKIM_REGISTRY`     | Yes                           | Address of the already-deployed `DKIMRegistry` contract.                                   |
-| `RPC_URL`           | Yes                           | RPC URL for the target network.                                                            |
-| `CHAIN_ID`          | Optional                      | Numeric chain ID used by `script/verify-zk-email-verifier.sh` (Foundry helper).           |
-| `ETHERSCAN_API_KEY` | For verification only | API key for Etherscan-compatible block explorer (for example Base Sepolia). |
+| Variable            | Required              | Description                                                                                            |
+| ------------------- | --------------------- | ------------------------------------------------------------------------------------------------------ |
+| `PRIVATE_KEY`       | Yes                   | EOA private key used to broadcast transactions (Hardhat `accounts` when set).                          |
+| `DKIM_REGISTRY`     | Yes                   | Address of the already-deployed `DKIMRegistry` contract.                                               |
+| `RPC_URL`           | See below             | Overrides the default public RPC for **numeric** networks in `hardhat.config.ts` (see next paragraph). |
+| `CHAIN_ID`          | Optional              | Numeric chain ID used by `script/verify-zk-email-verifier.sh` (Foundry helper).                        |
+| `ETHERSCAN_API_KEY` | For verification only | API key for Etherscan-compatible block explorer (for example Base Sepolia).                            |
+
+**Hardhat and `RPC_URL` / `PRIVATE_KEY`:** In [`hardhat.config.ts`](./hardhat.config.ts), networks keyed by chain id — `420420417` (Polkadot Hub testnet), `84532` (Base Sepolia), `11155111` (Ethereum Sepolia) — use `process.env.RPC_URL` when set, otherwise each chain’s default HTTPS RPC. `PRIVATE_KEY` populates `accounts` for those networks. The Circom pipeline sets the same variables from the blueprint payload before `yarn deploy <chain_id>`, so deploy targets the RPC and signer from the payload without editing the config. One `RPC_URL` value applies to whichever numeric network you pass to `yarn deploy <chain_id>` in that shell. Profiles `localEvm` and `localPvm` keep fixed `http://127.0.0.1:8545` URLs; `PRIVATE_KEY` is only attached when set so local node for pvm defaults still work when you omit it.
 
 ### Deploying with Hardhat Ignition
 
@@ -67,7 +69,7 @@ Build:
 yarn build
 ```
 
-Deploy (pass a network from `hardhat.config.ts`, e.g. `84532` for Base Sepolia or `420420417` for Polkadot Hub Testnet):
+Deploy (pass a network from `hardhat.config.ts`, e.g. `localPvm` / `localEvm` for local PolkaVM-compatible RPC or local Anvil, `84532` for Base Sepolia, `420420417` for Polkadot Hub testnet, or `11155111` for Ethereum Sepolia):
 
 ```bash
 yarn deploy 84532
@@ -81,20 +83,10 @@ yarn verify chain-84532
 
 Hardhat Ignition stores deployment artifacts under `hh-ignition/deployments`, and verification uses those artifacts.
 
-### Optional: deploying with Foundry script
-
-For manual/advanced flows you can still use the Foundry script:
-
-```bash
-forge script script/DeployZKEmailVerifier.s.sol:DeployZKEmailVerifierScript \
-  --rpc-url $RPC_URL \
-  --broadcast
-```
-
 ### All available commands
 
-| Command       | Description                                                                 |
-| ------------- | --------------------------------------------------------------------------- |
-| `yarn build`  | Compile contracts with Hardhat (`hardhat compile`).                         |
+| Command       | Description                                                                  |
+| ------------- | ---------------------------------------------------------------------------- |
+| `yarn build`  | Compile contracts with Hardhat (`hardhat compile`).                          |
 | `yarn deploy` | Deploy with Hardhat Ignition (`hardhat ignition deploy ... --network <id>`). |
-| `yarn verify` | Verify Ignition deployments (use `yarn verify chain-<chainid>`). |
+| `yarn verify` | Verify Ignition deployments (use `yarn verify chain-<chainid>`).             |

--- a/circom/contracts/hardhat.config.ts
+++ b/circom/contracts/hardhat.config.ts
@@ -5,6 +5,9 @@ import "@nomicfoundation/hardhat-verify";
 import "@parity/hardhat-polkadot";
 import "dotenv/config";
 
+const rpcUrl = process.env.RPC_URL;
+const accounts = process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [];
+
 const config: HardhatUserConfig = {
   networks: {
     hardhat: {
@@ -21,24 +24,34 @@ const config: HardhatUserConfig = {
         dev: true,
       },
     },
-    localNode: {
+    localEvm: {
+      url: "http://127.0.0.1:8545/",
+      ...(accounts.length ? { accounts } : {}),
+    },
+    localPvm: {
       polkadot: {
         target: "pvm",
       },
       url: `http://127.0.0.1:8545`,
+      ...(accounts.length ? { accounts } : {}),
     },
     // Polkadot Hub Testnet
     "420420417": {
       polkadot: {
         target: "pvm",
       },
-      url: "https://services.polkadothub-rpc.com/testnet",
-      accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [],
+      url: rpcUrl || "https://services.polkadothub-rpc.com/testnet",
+      accounts,
     },
     // Base Sepolia
     "84532": {
-      url: "https://sepolia.base.org",
-      accounts: process.env.PRIVATE_KEY ? [process.env.PRIVATE_KEY] : [],
+      url: rpcUrl || "https://sepolia.base.org",
+      accounts,
+    },
+    // Ethereum Sepolia
+    "11155111": {
+      url: rpcUrl || "https://ethereum-sepolia-rpc.publicnode.com",
+      accounts,
     },
   },
   etherscan: {
@@ -50,6 +63,14 @@ const config: HardhatUserConfig = {
         urls: {
           apiURL: "https://api-sepolia.basescan.org/api",
           browserURL: "https://sepolia.basescan.org/",
+        },
+      },
+      {
+        chainId: 11155111,
+        network: "11155111",
+        urls: {
+          apiURL: "https://api-sepolia.etherscan.io/api",
+          browserURL: "https://sepolia.etherscan.io/",
         },
       },
     ],

--- a/circom/contracts/hardhat.config.ts
+++ b/circom/contracts/hardhat.config.ts
@@ -101,6 +101,20 @@ const config: HardhatUserConfig = {
     artifacts: "hh-artifacts",
     ignition: "hh-ignition",
   },
+  ignition: {
+    // IGN401 fix for PolkaVM / Paseo AssetHub:
+    // The EVM-RPC adapter briefly returns null from eth_getTransaction right after
+    // a tx is included (indexing gap). Default maxRetries=10 × retryInterval=1s
+    // gives only 10s to detect the tx before IGN401 is thrown. 60s is enough.
+    maxRetries: 60,
+    // Stop Ignition from sending replacement txs (same nonce, higher gas): the
+    // EVM-RPC adapter does not handle them well and can make the original tx also
+    // appear dropped.
+    disableFeeBumping: true,
+    // PolkaVM uses GRANDPA deterministic finality — 1 confirmation is truly final.
+    // Default is 5.
+    requiredConfirmations: 1,
+  },
 };
 
 export default config;

--- a/circom/src/contract.rs
+++ b/circom/src/contract.rs
@@ -307,16 +307,12 @@ pub async fn deploy_verifier_contract(chain_id: u32) -> Result<String> {
     Ok(zk_email_verifier)
 }
 
-fn read_ignition_deployed_address(chain_id: u32) -> Result<Option<String>> {
-    let path = format!(
-        "tmp/contracts/hh-ignition/deployments/chain-{}/deployed_addresses.json",
-        chain_id
-    );
-
-    if !Path::new(&path).exists() {
+/// Parses Ignition `deployed_addresses.json` and returns `ZKEmailVerifierModule#ZKEmailVerifier` if present.
+pub fn read_zkemail_verifier_from_deployed_addresses_path(path: &Path) -> Result<Option<String>> {
+    if !path.exists() {
         return Err(anyhow::anyhow!(
             "Ignition deployed addresses file not found at {}",
-            path
+            path.display()
         ));
     }
 
@@ -331,8 +327,17 @@ fn read_ignition_deployed_address(chain_id: u32) -> Result<Option<String>> {
     Ok(zk_email_verifier)
 }
 
+fn read_ignition_deployed_address(chain_id: u32) -> Result<Option<String>> {
+    let path = Path::new("tmp/contracts/hh-ignition/deployments")
+        .join(format!("chain-{chain_id}"))
+        .join("deployed_addresses.json");
+    read_zkemail_verifier_from_deployed_addresses_path(&path)
+}
+
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
     use super::prepare_contract_data;
     use crate::payload::{Payload, UploadUrls};
     use sdk_utils::proto_types::proto_blueprint::{
@@ -466,4 +471,40 @@ mod tests {
         let data = prepare_contract_data(&payload);
         assert_eq!(data.signal_size, 5);
     }
+
+    #[test]
+    fn ignition_deployed_addresses_reads_zkemail_verifier() {
+        use super::read_zkemail_verifier_from_deployed_addresses_path;
+        let dir = std::env::temp_dir().join(format!(
+            "circom_ignition_deployed_addresses_{}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("deployed_addresses.json");
+        fs::write(
+            &path,
+            r#"{"ZKEmailVerifierModule#ZKEmailVerifier":"0xabcdef0123456789abcdef0123456789abcdef01","ZKEmailVerifierModule#Groth16Verifier":"0x1111111111111111111111111111111111111111"}"#,
+        )
+        .unwrap();
+        let addr = read_zkemail_verifier_from_deployed_addresses_path(&path).unwrap();
+        assert_eq!(
+            addr.as_deref(),
+            Some("0xabcdef0123456789abcdef0123456789abcdef01")
+        );
+        fs::remove_dir_all(&dir).ok();
+    }
+
+    #[test]
+    fn ignition_deployed_addresses_errors_when_file_missing() {
+        use super::read_zkemail_verifier_from_deployed_addresses_path;
+        let dir = std::env::temp_dir().join(format!(
+            "circom_ignition_missing_json_{}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("missing.json");
+        assert!(read_zkemail_verifier_from_deployed_addresses_path(&path).is_err());
+        fs::remove_dir_all(&dir).ok();
+    }
+
 }

--- a/circom/src/payload.rs
+++ b/circom/src/payload.rs
@@ -63,20 +63,8 @@ pub fn load_payload() -> Result<Payload> {
     info!(LOG, "Setting ENV variables");
     env::set_var("JSON_LOGGER", "true");
 
-    if !payload.private_key.is_empty() {
-        env::set_var("PRIVATE_KEY", &payload.private_key);
-    }
-    if !payload.rpc_url.is_empty() {
-        env::set_var("RPC_URL", &payload.rpc_url);
-    }
-    if payload.chain_id != 0 {
-        env::set_var("CHAIN_ID", payload.chain_id.to_string());
-    }
-    if !payload.etherscan_api_key.is_empty() {
-        env::set_var("ETHERSCAN_API_KEY", &payload.etherscan_api_key);
-    }
-    if !payload.dkim_registry_address.is_empty() {
-        env::set_var("DKIM_REGISTRY", &payload.dkim_registry_address);
+    for (key, value) in hardhat_deploy_env_from_payload(&payload) {
+        env::set_var(key, value);
     }
 
     // Check if TACHYON_DIR is set
@@ -94,3 +82,143 @@ pub fn load_payload() -> Result<Payload> {
 
     Ok(payload)
 }
+
+/// Environment variables derived from [`Payload`] for Hardhat / Ignition deploy (`yarn deploy`).
+/// Empty strings and `chain_id == 0` are skipped (same rules as the previous inline logic).
+pub fn hardhat_deploy_env_from_payload(payload: &Payload) -> Vec<(String, String)> {
+    let mut out = Vec::new();
+    if !payload.private_key.is_empty() {
+        out.push(("PRIVATE_KEY".to_string(), payload.private_key.clone()));
+    }
+    if !payload.rpc_url.is_empty() {
+        out.push(("RPC_URL".to_string(), payload.rpc_url.clone()));
+    }
+    if payload.chain_id != 0 {
+        out.push(("CHAIN_ID".to_string(), payload.chain_id.to_string()));
+    }
+    if !payload.etherscan_api_key.is_empty() {
+        out.push((
+            "ETHERSCAN_API_KEY".to_string(),
+            payload.etherscan_api_key.clone(),
+        ));
+    }
+    if !payload.dkim_registry_address.is_empty() {
+        out.push((
+            "DKIM_REGISTRY".to_string(),
+            payload.dkim_registry_address.clone(),
+        ));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{hardhat_deploy_env_from_payload, Payload, UploadUrls};
+    use sdk_utils::proto_types::proto_blueprint::Blueprint;
+
+    fn minimal_payload(
+        private_key: &str,
+        rpc_url: &str,
+        chain_id: u32,
+        etherscan: &str,
+        dkim: &str,
+    ) -> Payload {
+        Payload {
+            blueprint: Blueprint {
+                internal_version: "v2".to_string(),
+                id: "00000000-0000-0000-0000-000000000001".to_string(),
+                title: "t".to_string(),
+                description: "t".to_string(),
+                slug: "t/t".to_string(),
+                tags: vec![],
+                email_query: "from:x.com".to_string(),
+                circuit_name: "C".to_string(),
+                ignore_body_hash_check: true,
+                sha_precompute_selector: "".to_string(),
+                email_body_max_length: 0,
+                sender_domain: "x.com".to_string(),
+                enable_header_masking: false,
+                enable_body_masking: false,
+                client_zk_framework: 1,
+                server_zk_framework: 0,
+                verifier_contract_chain: chain_id as i32,
+                verifier_contract_address: "".to_string(),
+                is_public: true,
+                created_at: None,
+                updated_at: None,
+                external_inputs: vec![],
+                decomposed_regexes: vec![],
+                client_status: 1,
+                server_status: 3,
+                version: 1,
+                github_username: "t".to_string(),
+                email_header_max_length: 1024,
+                remove_soft_linebreaks: false,
+                stars: 0,
+                ptau: 0,
+                num_local_proofs: 0,
+            },
+            upload_urls: UploadUrls {
+                circuit: "".to_string(),
+                circuit_cpp: "".to_string(),
+                circuit_wasm: "".to_string(),
+                witness_calculator: "".to_string(),
+                generate_witness: "".to_string(),
+                circuit_full_zkey: "".to_string(),
+                vk: "".to_string(),
+                circuit_zkey: "".to_string(),
+                zkey_b: "".to_string(),
+                zkey_c: "".to_string(),
+                zkey_d: "".to_string(),
+                zkey_e: "".to_string(),
+                zkey_f: "".to_string(),
+                zkey_g: "".to_string(),
+                zkey_h: "".to_string(),
+                zkey_i: "".to_string(),
+                zkey_j: "".to_string(),
+                zkey_k: "".to_string(),
+                circom_regex_graphs: "".to_string(),
+            },
+            database_url: "".to_string(),
+            private_key: private_key.to_string(),
+            rpc_url: rpc_url.to_string(),
+            chain_id,
+            etherscan_api_key: etherscan.to_string(),
+            dkim_registry_address: dkim.to_string(),
+        }
+    }
+
+    #[test]
+    fn hardhat_env_from_payload_maps_deploy_fields() {
+        let p = minimal_payload(
+            "0xabc",
+            "https://rpc.example",
+            420420417,
+            "etherscan_key",
+            "0x70997970C51812dc3A010C7d01b50e0d17dc79C8",
+        );
+        let pairs: Vec<(String, String)> = hardhat_deploy_env_from_payload(&p)
+            .into_iter()
+            .collect();
+        assert_eq!(
+            pairs,
+            vec![
+                ("PRIVATE_KEY".to_string(), "0xabc".to_string()),
+                ("RPC_URL".to_string(), "https://rpc.example".to_string()),
+                ("CHAIN_ID".to_string(), "420420417".to_string()),
+                ("ETHERSCAN_API_KEY".to_string(), "etherscan_key".to_string()),
+                (
+                    "DKIM_REGISTRY".to_string(),
+                    "0x70997970C51812dc3A010C7d01b50e0d17dc79C8".to_string()
+                ),
+            ]
+        );
+    }
+
+    #[test]
+    fn hardhat_env_from_payload_skips_empty_fields() {
+        let p = minimal_payload("", "", 0, "", "");
+        assert!(hardhat_deploy_env_from_payload(&p).is_empty());
+    }
+}
+


### PR DESCRIPTION
## Changes

  ### Fix: reliable Ignition deployment to Paseo AssetHub (PolkaVM)

  Adds an `ignition` config block to `hardhat.config.ts` to fix intermittent `IGN401` failures when deploying to Paseo AssetHub (chain 420420417).

  **Root cause:** Ignition detects a "dropped" transaction by calling `eth_getTransaction` for every submitted tx hash, retrying `maxRetries` (default 10) times
   × `retryInterval` (1s) = 10 seconds before throwing IGN401. The PolkaVM EVM-RPC adapter briefly returns `null` from `eth_getTransaction` right after a
  transaction is included in a block (indexing gap between inclusion and the adapter catching up). 10 seconds is too short to survive this gap, especially under
   cloud network latency.

  Reproduced locally: 2/3 consecutive runs succeeded without the fix, 3rd failed with IGN401. All 3 passed with the fix applied.

  **Settings applied:**
  - `maxRetries: 60` — gives 60 s to find the tx instead of 10 s, enough to survive the EVM adapter indexing gap
  - `disableFeeBumping: true` — prevents Ignition from sending replacement transactions (same nonce, higher gas) that further confuse the adapter and can make
  the original tx also appear dropped
  - `requiredConfirmations: 1` — PolkaVM uses GRANDPA deterministic finality; once a block is included it cannot be reorganized, so 1 confirmation is
  cryptographically final (default is 5, appropriate for Ethereum's probabilistic Nakamoto consensus but unnecessary here)

  ### Hardhat env-based RPC/accounts and deploy test helpers
  - `hardhat.config.ts`: RPC_URL and PRIVATE_KEY override defaults for numeric testnets; add Ethereum Sepolia (11155111); local profiles optional accounts
  - `contracts README`: document env interaction with pipeline and networks
  - `payload.rs`: `hardhat_deploy_env_from_payload` + unit tests for deploy env
  - `contract.rs`: `read_zkemail_verifier_from_deployed_addresses_path` + tests