### PR TITLE
chore: remove dev environment from CI/CD workflows

### DIFF
--- a/.github/workflows/build-push-deploy-circom.yml
+++ b/.github/workflows/build-push-deploy-circom.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - main
       - staging
-      - dev
     paths:
       - 'circom/**'
       - 'sdk-utils/**'
@@ -15,10 +14,9 @@ on:
       branch:
         description: 'Branch to build from'
         required: false
-        default: 'dev'
+        default: 'staging'
         type: choice
         options:
-          - dev
           - staging
           - main
 

--- a/.github/workflows/build-push-deploy-noir.yml
+++ b/.github/workflows/build-push-deploy-noir.yml
@@ -2,7 +2,7 @@ name: Build Push Deploy Noir
 
 on:
   push:
-    branches: [main, staging, dev]
+    branches: [main, staging]
     paths:
       - 'noir/**'
       - 'sdk-utils/**'
@@ -16,7 +16,7 @@ on:
         description: 'Target environment'
         required: false
         type: choice
-        options: [dev, staging, production]
+        options: [staging, production]
 
 permissions:
   id-token: write
@@ -60,9 +60,6 @@ jobs:
             # Auto from branch
             BRANCH="${GITHUB_REF##*/}"
             case "$BRANCH" in
-              dev)
-                ENVIRONMENT="dev"
-                ;;
               staging)
                 ENVIRONMENT="staging"
                 ;;

--- a/.github/workflows/manual-deploy-circom.yml
+++ b/.github/workflows/manual-deploy-circom.yml
@@ -13,7 +13,6 @@ on:
         type: choice
         options:
           - staging
-          - dev
 
 permissions:
   id-token: write


### PR DESCRIPTION
## Summary

- Removes `dev` branch trigger from `build-push-deploy-circom`
- Removes `dev` from environment mapping in `build-push-deploy-noir`
- Removes `dev` option from `manual-deploy-circom` workflow dispatch

Part of dev environment decommissioning.