### PR TITLE
ci(circom): run cargo test on push/PR to main/staging

### DIFF
--- a/.github/workflows/circom-rust-tests.yml
+++ b/.github/workflows/circom-rust-tests.yml
@@ -9,6 +9,14 @@ on:
       - 'circom/**'
       - 'sdk-utils/**'
       - 'Cargo.toml'
+  pull_request:
+    branches:
+      - main
+      - staging
+    paths:
+      - 'circom/**'
+      - 'sdk-utils/**'
+      - 'Cargo.toml'
   workflow_dispatch: {}
 
 jobs:

--- a/.github/workflows/circom-rust-tests.yml
+++ b/.github/workflows/circom-rust-tests.yml
@@ -1,0 +1,46 @@
+name: Circom Rust tests
+
+on:
+  push:
+    branches:
+      - main
+      - staging
+    paths:
+      - 'circom/**'
+      - 'sdk-utils/**'
+      - 'Cargo.toml'
+  workflow_dispatch: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            .
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install circom
+        run: |
+          git clone https://github.com/iden3/circom.git /tmp/circom-src
+          cd /tmp/circom-src
+          git checkout tags/v2.1.9 -b v2.1.9
+          cargo build --release
+          cargo install --path circom
+
+      - name: Run circom crate tests
+        # --test-threads=1: several tests share a hardcoded ./tmp working directory
+        # (via prepare_contract_data's setup()/cleanup()), so running them in parallel
+        # races on that shared state. Serializing avoids the race; these tests aren't
+        # on a fast feedback loop, so the extra time is an acceptable trade-off over
+        # refactoring the shared tmp-dir handling.
+        run: cargo test -p circom -- --test-threads=1

--- a/circom/src/main.rs
+++ b/circom/src/main.rs
@@ -955,6 +955,10 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore] // ZK-1453: template.circom.tera's regex call site is hardcoded to a single
+              // capture group, so any regex with 2+ public parts (like this blueprint's
+              // EmailSubject) fails to compile with a circom TAC01 arity error. Pre-existing,
+              // unrelated to this crate's Rust logic.
     async fn test_compile_circuit_kraken() {
         let blueprint = Blueprint {
             internal_version: "v2".to_string(),


### PR DESCRIPTION
## Summary
- No workflow currently runs the `circom` crate's Rust tests at all — `build-push-deploy-circom.yml` only builds and pushes a Docker image.
- Adds `circom-rust-tests.yml`: runs `cargo test -p circom` on push and PR against `main`/`staging` (plus `workflow_dispatch`), scoped to just the circom crate (not noir).
- Serialized (`--test-threads=1`): several `main.rs` integration tests share a hardcoded `./tmp` working directory, and race under parallel execution. Verified locally: 3 of the previously-parallel-flaky tests pass cleanly once serialized.
- `test_compile_circuit_kraken` is `#[ignore]`d, tracked as [ZK-1453](https://linear.app/zk-email/issue/ZK-1453): a pre-existing bug in `template.circom.tera` breaks compilation for any regex with 2+ public parts. Confirmed via `git stash` that this fails identically with or without any other pending changes — genuinely pre-existing, unrelated to this PR.

## Test plan
- [x] Ran `cargo test -p circom -- --test-threads=1` locally: 11 passed, 0 failed, 1 ignored, in ~7 minutes.
- [ ] Confirm the workflow itself runs green on GitHub Actions once opened (installs circom v2.1.9 from source, matching `circom/Dockerfile`'s pinned version).