### PR TITLE
ci(circom): fix protoc failure, use prebuilt circom binary

### DIFF
--- a/.github/workflows/circom-rust-tests.yml
+++ b/.github/workflows/circom-rust-tests.yml
@@ -37,13 +37,18 @@ jobs:
         with:
           node-version: 20
 
+      - name: Install protoc
+        # Required by prost-wkt-types' build script (a transitive dependency); without it,
+        # compiling the crate's own test binary fails before any test runs.
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
       - name: Install circom
+        # Prebuilt binary (matches circom/Dockerfile's pinned v2.1.9) instead of building from
+        # source: ~seconds instead of ~2 minutes for a cold `cargo build --release` of circom
+        # itself, which has nothing to do with this crate's own build cache.
         run: |
-          git clone https://github.com/iden3/circom.git /tmp/circom-src
-          cd /tmp/circom-src
-          git checkout tags/v2.1.9 -b v2.1.9
-          cargo build --release
-          cargo install --path circom
+          curl -L -o /usr/local/bin/circom https://github.com/iden3/circom/releases/download/v2.1.9/circom-linux-amd64
+          chmod +x /usr/local/bin/circom
 
       - name: Run circom crate tests
         # --test-threads=1: several tests share a hardcoded ./tmp working directory


### PR DESCRIPTION
## Summary
Follow-up to #65, whose first run on \`staging\` [failed](https://github.com/zkemail/sdk-images/actions/runs/30108138607).

- **Real bug**: \`cargo test\` failed to compile at all -- \`prost-wkt-types\`' build script needs \`protoc\`, which nothing installed. Add \`apt-get install protobuf-compiler\` (matches \`circom/Dockerfile\`).
- **Speed**: circom's \`Install circom\` step took 2m10s building from source on a cold run, for a binary that doesn't change between runs. Switched to downloading the prebuilt \`circom-linux-amd64\` binary from circom's own v2.1.9 GitHub release instead (verified locally: downloads correctly, is a valid Linux x86-64 ELF binary matching the runner's arch).

## Test plan
- [ ] Confirm this run goes green on GitHub Actions (installs protoc, downloads circom, runs `cargo test -p circom -- --test-threads=1`).