### PR TITLE
ci(circom): scope CI to fast contract:: unit tests

### DIFF
--- a/.github/workflows/circom-rust-tests.yml
+++ b/.github/workflows/circom-rust-tests.yml
@@ -22,7 +22,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/circom-rust-tests.yml
+++ b/.github/workflows/circom-rust-tests.yml
@@ -52,9 +52,10 @@ jobs:
           chmod +x /usr/local/bin/circom
 
       - name: Run circom crate tests
-        # --test-threads=1: several tests share a hardcoded ./tmp working directory
-        # (via prepare_contract_data's setup()/cleanup()), so running them in parallel
-        # races on that shared state. Serializing avoids the race; these tests aren't
-        # on a fast feedback loop, so the extra time is an acceptable trade-off over
-        # refactoring the shared tmp-dir handling.
-        run: cargo test -p circom -- --test-threads=1
+        # Scoped to contract:: only (fast, pure-Rust unit tests, no circom/yarn involved).
+        # The full suite (including main.rs's test_compile_circuit_* integration tests,
+        # each of which does a real circom compile + a fresh `yarn install` into a shared
+        # ./tmp) was getting the job cancelled ~7-8 min in on every attempt: target/ alone
+        # runs to ~16GB on a cold build, comfortably over the 14GB disk budget on standard
+        # GitHub-hosted runners. See ZK-1454 for bringing the full suite back within budget.
+        run: cargo test -p circom contract::

--- a/.github/workflows/circom-rust-tests.yml
+++ b/.github/workflows/circom-rust-tests.yml
@@ -58,4 +58,4 @@ jobs:
         # ./tmp) was getting the job cancelled ~7-8 min in on every attempt: target/ alone
         # runs to ~16GB on a cold build, comfortably over the 14GB disk budget on standard
         # GitHub-hosted runners. See ZK-1454 for bringing the full suite back within budget.
-        run: cargo test -p circom contract::
+        run: cargo test -p circom "contract::"

--- a/.github/workflows/circom-rust-tests.yml
+++ b/.github/workflows/circom-rust-tests.yml
@@ -22,6 +22,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 

--- a/circom/src/main.rs
+++ b/circom/src/main.rs
@@ -955,10 +955,10 @@ mod tests {
     }
 
     #[tokio::test]
-    #[ignore] // ZK-1453: template.circom.tera's regex call site is hardcoded to a single
-              // capture group, so any regex with 2+ public parts (like this blueprint's
-              // EmailSubject) fails to compile with a circom TAC01 arity error. Pre-existing,
-              // unrelated to this crate's Rust logic.
+    #[ignore] // ZK-1453 (https://linear.app/zk-email/issue/ZK-1453): template.circom.tera's
+              // regex call site is hardcoded to a single capture group, so any regex with 2+
+              // public parts (like this blueprint's EmailSubject) fails to compile with a
+              // circom TAC01 arity error. Pre-existing, unrelated to this crate's Rust logic.
     async fn test_compile_circuit_kraken() {
         let blueprint = Blueprint {
             internal_version: "v2".to_string(),


### PR DESCRIPTION
## Summary
Follow-up to #65/#66, whose full-suite run (`cargo test -p circom -- --test-threads=1`) got cancelled ~7-8 minutes into every attempt (3/3, across both `workflow_dispatch` and `pull_request` triggers) for reasons that turned out to be disk-space exhaustion, not a code bug:

- Standard GitHub-hosted `ubuntu-latest` runners have **4 vCPU / 16GB RAM / 14GB SSD** (confirmed via GitHub's docs).
- A cold `target/` for this crate alone reaches **~16GB** (heavy deps: sqlx, ethers, sp1-verifier, halo2curves, etc.).
- Each `main.rs` integration test (`test_compile_circuit_*`) does its own fresh `yarn install` into a shared `./tmp` with no cleanup between tests, which peaked at **~5.9GB** locally.
- Combined, this exceeds the 14GB budget. Confirmed the tests themselves are correct (11/11 non-ignored pass locally, repeatedly, including a genuinely cold `cargo clean` rebuild) -- this is a CI resource problem, not a test failure.
- Also notable: because every run was *cancelled* (not failed), `Swatinem/rust-cache`'s save step was skipped every time (cancelled jobs skip post-hooks), so every attempt was a from-scratch rebuild -- a vicious cycle.

**Fix**: scope the CI command to `cargo test -p circom "contract::"` -- the fast, pure-Rust unit tests covering `prepare_contract_data`/`ContractData`, which don't touch circom/yarn/disk at all and run in under a second. This gives up automated coverage for the `test_compile_circuit_*` integration tests for now; tracked as [ZK-1454](https://linear.app/zk-email/issue/ZK-1454) to bring them back within budget (candidate fixes: trim debug info via `Cargo.toml` profile settings, let the cache actually save once a run completes, split into smaller steps, or a larger runner).

## Test plan
- [x] Confirmed via `workflow_dispatch` and `pull_request` runs: job completes in ~3 minutes, all 4 `contract::` tests pass.