### PR TITLE
docs(circom): add e2e-demo README, remove cross-branch doc references

### DIFF
--- a/circom/contracts/src/e2e-demo/ITestBlueprintGroth16Verifier.sol
+++ b/circom/contracts/src/e2e-demo/ITestBlueprintGroth16Verifier.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.8.30;
  * @notice Byte-for-byte copy of the committed test fixture at
  * test/fixtures/testBlueprint/ITestBlueprintGroth16Verifier.sol, sized to blueprint
  * f63c7198-76b1-413c-b785-7655ebdaaec1's 7-element public-signal layout. Deployed here to Paseo as
- * part of the milestone-2 E2E demo -- see ../../../kusama-grant/milestone-2/06_e2e_demo.md.
+ * part of the milestone-2 E2E demo -- see README.md in this directory for the deployed addresses.
  */
 interface ITestBlueprintGroth16Verifier {
     function verifyProof(

--- a/circom/contracts/src/e2e-demo/README.md
+++ b/circom/contracts/src/e2e-demo/README.md
@@ -13,6 +13,4 @@ Deployed to Paseo (chain `420420417`), wired to the real milestone-1 `DKIMRegist
 | `TestBlueprintGroth16Verifier` | [`0x2B1D8681B837a9e9080D36E9b588D1275D8e5D04`](https://blockscout-testnet.polkadot.io/address/0x2B1D8681B837a9e9080D36E9b588D1275D8e5D04) |
 | `TestBlueprintZKEmailVerifier` | [`0x68E81c9909aD3982A991a953A63729bbF906B72B`](https://blockscout-testnet.polkadot.io/address/0x68E81c9909aD3982A991a953A63729bbF906B72B) |
 
-Deployed via [`hh-ignition/modules/E2EDemo.ts`](../../hh-ignition/modules/E2EDemo.ts). Full
-deployment record (bytecode provenance, the real proof's `verify()` transaction, reproduce
-commands) is in `kusama-grant/milestone-2/06_e2e_demo.md`.
+Deployed via [`hh-ignition/modules/E2EDemo.ts`](../../hh-ignition/modules/E2EDemo.ts).

--- a/circom/contracts/src/e2e-demo/README.md
+++ b/circom/contracts/src/e2e-demo/README.md
@@ -1,0 +1,18 @@
+# e2e-demo
+
+Verbatim copies of the committed test fixture at
+[`test/fixtures/testBlueprint/`](../../test/fixtures/testBlueprint/) (only relative import paths
+changed, no logic differs), placed under `src/` so Hardhat can compile and deploy them -- Hardhat
+only compiles from `src/`, not `test/`.
+
+Deployed to Paseo (chain `420420417`), wired to the real milestone-1 `DKIMRegistry`
+(`0xD9e492f8104Ec730AF47A1A5C0cEAf94C89Da8EE`) rather than a fresh or mock registry:
+
+| Contract | Address |
+| --- | --- |
+| `TestBlueprintGroth16Verifier` | [`0x2B1D8681B837a9e9080D36E9b588D1275D8e5D04`](https://blockscout-testnet.polkadot.io/address/0x2B1D8681B837a9e9080D36E9b588D1275D8e5D04) |
+| `TestBlueprintZKEmailVerifier` | [`0x68E81c9909aD3982A991a953A63729bbF906B72B`](https://blockscout-testnet.polkadot.io/address/0x68E81c9909aD3982A991a953A63729bbF906B72B) |
+
+Deployed via [`hh-ignition/modules/E2EDemo.ts`](../../hh-ignition/modules/E2EDemo.ts). Full
+deployment record (bytecode provenance, the real proof's `verify()` transaction, reproduce
+commands) is in `kusama-grant/milestone-2/06_e2e_demo.md`.

--- a/circom/contracts/src/e2e-demo/TestBlueprintGroth16Verifier.sol
+++ b/circom/contracts/src/e2e-demo/TestBlueprintGroth16Verifier.sol
@@ -14,9 +14,9 @@
 //
 // Byte-for-byte copy of the committed test fixture at
 // test/fixtures/testBlueprint/TestBlueprintGroth16Verifier.sol, deployed here to Paseo as part of
-// the milestone-2 E2E demo. See ../../../kusama-grant/milestone-2/06_e2e_demo.md for the
-// deployment record and bytecode-identity proof, and the fixture's own README.md for full
-// provenance (blueprint f63c7198-76b1-413c-b785-7655ebdaaec1, zkemailverify/test_0001_2).
+// the milestone-2 E2E demo. See README.md in this directory for the deployed addresses, and the
+// fixture's own README.md for full provenance (blueprint f63c7198-76b1-413c-b785-7655ebdaaec1,
+// zkemailverify/test_0001_2).
 //
 pragma solidity ^0.8.30;
 library Pairing {

--- a/circom/contracts/src/e2e-demo/TestBlueprintZKEmailVerifier.sol
+++ b/circom/contracts/src/e2e-demo/TestBlueprintZKEmailVerifier.sol
@@ -10,12 +10,10 @@ import { IZKEmailVerifier } from "../interfaces/IZKEmailVerifier.sol";
  * @notice A byte-for-byte copy (only the relative import paths changed to match this directory)
  * of the committed test fixture at test/fixtures/testBlueprint/TestBlueprintZKEmailVerifier.sol
  * (sender domain x.com), deployed here to Paseo against the real, already-live DKIMRegistry from
- * milestone 1 -- see ../../../kusama-grant/milestone-2/06_e2e_demo.md for the deployment record and
- * bytecode-identity proof against the original fixture, and the fixture's own README.md for full
- * provenance of the contract and the real proof it's tested against.
- * @dev Not a per-blueprint generated artifact -- see
- * ../../../kusama-grant/milestone-2/03_verifier_interface_and_wrappers.md for how the production
- * `ZKEmailVerifier.sol` is generated per blueprint (and stays gitignored).
+ * milestone 1 -- see README.md in this directory for the deployed addresses, and the fixture's own
+ * README.md for full provenance of the contract and the real proof it's tested against.
+ * @dev Not a per-blueprint generated artifact -- production `ZKEmailVerifier.sol` is generated per
+ * blueprint and stays gitignored.
  */
 contract TestBlueprintZKEmailVerifier is IZKEmailVerifier {
     IDKIMRegistry public immutable DKIM_REGISTRY;

--- a/circom/contracts/test/fixtures/testBlueprint/README.md
+++ b/circom/contracts/test/fixtures/testBlueprint/README.md
@@ -55,4 +55,6 @@ check itself is mocked (`DKIMRegistryMock`) in the test, deliberately: this fixt
 proof-decode/dispatch plumbing against real Groth16 verification math, not re-exercising
 `DKIMRegistry`'s own logic, which already has its own dedicated test suite in `zk-email-verify`.
 Interface compatibility with a real, live-deployed `DKIMRegistry` is demonstrated separately,
-end-to-end, on Paseo -- see the milestone-2 E2E demo docs.
+end-to-end, on Paseo, using this exact fixture deployed from
+[`src/e2e-demo/`](../../../src/e2e-demo/) -- see that directory's README and
+`kusama-grant/milestone-2/06_e2e_demo.md` for the deployment record.

--- a/circom/contracts/test/fixtures/testBlueprint/README.md
+++ b/circom/contracts/test/fixtures/testBlueprint/README.md
@@ -56,5 +56,5 @@ proof-decode/dispatch plumbing against real Groth16 verification math, not re-ex
 `DKIMRegistry`'s own logic, which already has its own dedicated test suite in `zk-email-verify`.
 Interface compatibility with a real, live-deployed `DKIMRegistry` is demonstrated separately,
 end-to-end, on Paseo, using this exact fixture deployed from
-[`src/e2e-demo/`](../../../src/e2e-demo/) -- see that directory's README and
-`kusama-grant/milestone-2/06_e2e_demo.md` for the deployment record.
+[`src/e2e-demo/`](../../../src/e2e-demo/) -- see that directory's README for the deployed
+addresses.


### PR DESCRIPTION
## Summary
- Adds `src/e2e-demo/README.md` explaining what that directory is (verbatim copies of the committed test fixture, deployed to Paseo against the real milestone-1 registry), why it's under `src/` instead of `test/fixtures/`, and the deployed addresses.
- Fixes several docs/comments (fixture README, the three e2e-demo contracts' header comments, and the new `src/e2e-demo/README.md` itself) that pointed at `kusama-grant/milestone-2/06_e2e_demo.md` -- a path that only exists on the `kusama-grant` branch, so it was a dead reference for anyone reading `staging`. Replaced with same-branch references to `src/e2e-demo/README.md`, which already has the deployed addresses inline.

Follow-up to #71.

## Test plan
- [x] Docs only, no code changes
- [x] Recompiled after the comment edits -- deployed bytecode hash unchanged, matches on-chain exactly