### PR TITLE
ci(circom): widen rust-test filter to cover payload:: and bundle/zip test

### DIFF
--- a/.github/workflows/circom-rust-tests.yml
+++ b/.github/workflows/circom-rust-tests.yml
@@ -51,10 +51,14 @@ jobs:
           chmod +x /usr/local/bin/circom
 
       - name: Run circom crate tests
-        # Scoped to contract:: only (fast, pure-Rust unit tests, no circom/yarn involved).
-        # The full suite (including main.rs's test_compile_circuit_* integration tests,
-        # each of which does a real circom compile + a fresh `yarn install` into a shared
-        # ./tmp) was getting the job cancelled ~7-8 min in on every attempt: target/ alone
-        # runs to ~16GB on a cold build, comfortably over the 14GB disk budget on standard
-        # GitHub-hosted runners. See ZK-1454 for bringing the full suite back within budget.
-        run: cargo test -p circom "contract::"
+        # Scoped to contract:: and payload:: plus one named main.rs test, all fast
+        # pure-Rust unit tests with no circom/yarn involved. The full suite (including
+        # main.rs's test_compile_circuit_* integration tests, each of which does a real
+        # circom compile + a fresh `yarn install` into a shared ./tmp) was getting the
+        # job cancelled ~7-8 min in on every attempt: target/ alone runs to ~16GB on a
+        # cold build, comfortably over the 14GB disk budget on standard GitHub-hosted
+        # runners. See ZK-1454 for bringing the full suite back within budget.
+        run: |
+          cargo test -p circom "contract::"
+          cargo test -p circom "payload::"
+          cargo test -p circom test_contracts_bundle_and_zip_works


### PR DESCRIPTION
## Summary
- The `circom-rust-tests.yml` job was scoped to `contract::` only (ZK-1454: the full suite, including `main.rs`'s `test_compile_circuit_*` integration tests, blew the runner's 14GB disk budget with a real circom compile + fresh `yarn install` per test).
- `hardhat_env_from_payload_*` (`payload::`) and `test_contracts_bundle_and_zip_works` (`main.rs`) are cheap, pure-Rust unit tests with no circom compile or yarn install, so they don't hit that constraint.
- Adds them as their own `cargo test` invocations in the same step, `test_compile_circuit_*` stays excluded.

Needed so these tests (evidence for Kusama grant milestone-3 deliverables 1 and 2) actually run in CI instead of only locally.

## Test plan
- [x] Ran all three invocations locally (`contract::`, `payload::`, `test_contracts_bundle_and_zip_works`) -- all pass in well under a second each, no circom/yarn triggered.
- [x] CI run on this PR is green.